### PR TITLE
Final release of compactc 0.28.0 and compact-runtime 0.14.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -6,11 +6,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1715852961,
-        "narHash": "sha256-UKdGXLBlhWgDy5jE/f66NuHpG8oAPeQ+sA/qbNje6bI=",
+        "lastModified": 1769510086,
+        "narHash": "sha256-xINYSh4mb+WnzbonOiPDe1Ici7NeMP15V5Hv0YEAoLI=",
         "owner": "tkerber",
         "repo": "chez-exe",
-        "rev": "93943cffc121914bd88b05a4bb3a05c67e586cf7",
+        "rev": "c461925100efc25ada0e3f3b0844bdf1ba337b51",
         "type": "github"
       },
       "original": {
@@ -198,11 +198,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1768395095,
-        "narHash": "sha256-ZhuYJbwbZT32QA95tSkXd9zXHcdZj90EzHpEXBMabaw=",
+        "lastModified": 1769433173,
+        "narHash": "sha256-Gf1dFYgD344WZ3q0LPlRoWaNdNQq8kSBDLEWulRQSEs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13868c071cc73a5e9f610c47d7bb08e5da64fdd5",
+        "rev": "13b0f9e6ac78abbbb736c635d87845c4f4bee51b",
         "type": "github"
       },
       "original": {
@@ -335,16 +335,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1766436867,
-        "narHash": "sha256-Zm3mn/JM5QjgDC4MzcS/J59V3j/rQWsRDIFW/ErJ/aI=",
+        "lastModified": 1769539005,
+        "narHash": "sha256-I4e9AdBQYmAfy7XlVPhJ+6oC7a0oW99+Xm1KwrZxHTc=",
         "owner": "midnightntwrk",
         "repo": "midnight-ledger",
-        "rev": "f286bab87276136b2142932a4759ede03b800b03",
+        "rev": "8f2ed5c0954770e84b43c5dbb64ecb880d3e9e78",
         "type": "github"
       },
       "original": {
         "owner": "midnightntwrk",
-        "ref": "ledger-7.0.0-alpha.1",
+        "ref": "ledger-7.0.0",
         "repo": "midnight-ledger",
         "type": "github"
       }
@@ -649,16 +649,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1766436867,
-        "narHash": "sha256-Zm3mn/JM5QjgDC4MzcS/J59V3j/rQWsRDIFW/ErJ/aI=",
+        "lastModified": 1769539005,
+        "narHash": "sha256-I4e9AdBQYmAfy7XlVPhJ+6oC7a0oW99+Xm1KwrZxHTc=",
         "owner": "midnightntwrk",
         "repo": "midnight-ledger",
-        "rev": "f286bab87276136b2142932a4759ede03b800b03",
+        "rev": "8f2ed5c0954770e84b43c5dbb64ecb880d3e9e78",
         "type": "github"
       },
       "original": {
         "owner": "midnightntwrk",
-        "ref": "ledger-7.0.0-alpha.1",
+        "ref": "ledger-7.0.0",
         "repo": "midnight-ledger",
         "type": "github"
       }
@@ -674,16 +674,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1766436867,
-        "narHash": "sha256-Zm3mn/JM5QjgDC4MzcS/J59V3j/rQWsRDIFW/ErJ/aI=",
+        "lastModified": 1769539005,
+        "narHash": "sha256-I4e9AdBQYmAfy7XlVPhJ+6oC7a0oW99+Xm1KwrZxHTc=",
         "owner": "midnightntwrk",
         "repo": "midnight-ledger",
-        "rev": "f286bab87276136b2142932a4759ede03b800b03",
+        "rev": "8f2ed5c0954770e84b43c5dbb64ecb880d3e9e78",
         "type": "github"
       },
       "original": {
         "owner": "midnightntwrk",
-        "ref": "ledger-7.0.0-alpha.1",
+        "ref": "ledger-7.0.0",
         "repo": "midnight-ledger",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -25,24 +25,24 @@
   inputs = {
     zkir = {
       # dependency for compact-runtime release
-      # this is using a tag to pull in the correct zkir version from ledger-7.0.0-alpha.1 release
+      # this is using a tag to pull in the correct zkir version from ledger-7.0.0 release
       # if for releasing the runtime, running nix flake update causes errors for authorization of cargo, use
       # the commit hash instead of the tag for this.
       # NOTE: if this is an internal release (uses -alpha, -beta, or -rc) do NOT update the package.json in runtime
       # since npm can only access public releases. For the compact-runtime release nix will pull in the correct
       # version from this url.
-      url = "github:midnightntwrk/midnight-ledger/ledger-7.0.0-alpha.1";
+      url = "github:midnightntwrk/midnight-ledger/ledger-7.0.0";
       inputs.zkir.follows = "zkir";
     };
     onchain-runtime-v2 = {
       # dependency for compact-runtime release
       # all notes for the zkir input applies to onchain-runtime input too.
-      url = "github:midnightntwrk/midnight-ledger/ledger-7.0.0-alpha.1";
+      url = "github:midnightntwrk/midnight-ledger/ledger-7.0.0";
       inputs.zkir.follows = "zkir";
     };
     zkir-wasm = {
       # dependency for test-center
-      url = "github:midnightntwrk/midnight-ledger/ledger-7.0.0-alpha.1";
+      url = "github:midnightntwrk/midnight-ledger/ledger-7.0.0";
       inputs.zkir.follows = "zkir";
     };
     n2c.url = "github:nlewo/nix2container";

--- a/runtime/package-lock.json
+++ b/runtime/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@midnight-ntwrk/compact-runtime",
-  "version": "0.14.0-rc.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@midnight-ntwrk/compact-runtime",
-      "version": "0.14.0-rc.0",
+      "version": "0.14.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@midnight-ntwrk/onchain-runtime-v2": "^2.0.0-alpha.1",
+        "@midnight-ntwrk/onchain-runtime-v2": "^2.0.0",
         "@types/object-inspect": "^1.8.1",
         "object-inspect": "^1.12.3"
       },
@@ -662,9 +662,9 @@
       "license": "MIT"
     },
     "node_modules/@midnight-ntwrk/onchain-runtime-v2": {
-      "version": "2.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/onchain-runtime-v2/-/onchain-runtime-v2-2.0.0-alpha.1.tgz",
-      "integrity": "sha512-E8mom4Ykf6k22NXbN5+dV0nOy3XBAKptJUnDhOWzR2CSB8Ta1kDUmOK0+QfqOx3Del+EcNZbCQ0uFQ7r0pmjCg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/onchain-runtime-v2/-/onchain-runtime-v2-2.0.0.tgz",
+      "integrity": "sha512-9LfU3xJDI4aWcElE4ZxsGLKKAjj/7+O6nepvqMngojc+YLmlpR29ju4C+/isDbBk/4m/9m9fq89d8qIvX8Y4/Q=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/compact-runtime",
-  "version": "0.14.0-rc.0",
+  "version": "0.14.0",
   "description": "Compact Runtime",
   "type": "module",
   "exports": {
@@ -33,7 +33,7 @@
     "@midnight-ntwrk/onchain-runtime-v2"
   ],
   "dependencies": {
-    "@midnight-ntwrk/onchain-runtime-v2": "^2.0.0-alpha.1",
+    "@midnight-ntwrk/onchain-runtime-v2": "^2.0.0",
     "@types/object-inspect": "^1.8.1",
     "object-inspect": "^1.12.3"
   },


### PR DESCRIPTION
It updates flake.nix to pull in `ledger-7.0.0`.
It updates runtime/package.json to pull in `onchain-runtime-2.0.0` and bumps the version of compact-runtime to `0.14.0`.
It updates the locks of the above two files.

