### PR TITLE
Fixed: fixup-compact fails to look for source files relative to the path of the top-level source file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased compiler 0.28.109, language 0.20.102]
+
+### Fixed
+
+- The fixup tool fixup-compact.ss failed to look for include files and modules
+  relative to the directory of the source pathname.
+
 ## [Unreleased compiler 0.28.108, language 0.20.102]
 
 ### Removed

--- a/compiler/compiler-version.ss
+++ b/compiler/compiler-version.ss
@@ -20,7 +20,7 @@
   (import (chezscheme) (version))
 
   ; NB: also update compactc version in ../flake.nix
-  (define compiler-version (make-version 'compiler 0 28 108))
+  (define compiler-version (make-version 'compiler 0 28 109))
 
   (define compiler-version-string (make-version-string compiler-version))
 

--- a/compiler/fixup-compact.ss
+++ b/compiler/fixup-compact.ss
@@ -62,7 +62,8 @@ The following flags, if present, affect the tool's behavior as follows:
      (check-pathname source-pathname)
      (when target-pathname (check-pathname target-pathname))
      (handle-exceptions ?--vscode
-       (let ([s (parameterize ([update-Uint-ranges ?--update-Uint-ranges])
+       (let ([s (parameterize ([update-Uint-ranges ?--update-Uint-ranges]
+                               [relative-path (path-parent source-pathname)])
                   (parse-file/fixup/format source-pathname))])
          (if target-pathname
              (let ([op (guard (c [else (error-accessing-file c "creating output file")])

--- a/doc/ledger-adt.mdx
+++ b/doc/ledger-adt.mdx
@@ -1,6 +1,6 @@
 # Ledger data types
 
-Compact language version 0.20.102, compiler version 0.28.108.
+Compact language version 0.20.102, compiler version 0.28.109.
 
 ## Kernel
 

--- a/flake.nix
+++ b/flake.nix
@@ -202,7 +202,7 @@
 
           packages.compactc = pkgs.stdenv.mkDerivation {
             name = "compactc";
-            version = "0.28.108"; # NB: also update compiler-version in compiler/compiler-version.ss
+            version = "0.28.109"; # NB: also update compiler-version in compiler/compiler-version.ss
             src = inclusive.lib.inclusive ./. [
               ./test-center
               ./compiler


### PR DESCRIPTION
This addresses #64, though the fix won't be reflected in `compact fixup` until the 0.29.0 release of Compact is available and the user has updated to that release or a later one.

