### PR TITLE
Initial restructure

### DIFF
--- a/doc/lang-ref.mdx
+++ b/doc/lang-ref.mdx
@@ -33,7 +33,7 @@ To be filled in by @kent.dybvig. Note that the docs page already has a page
 before getting to the language reference that attempts to achieve what we
 discussed for the overview section. Once we add this it'd be a good idea to
 remove that page. Alternatively, we can also have this section as the page
-before the lang ref.
+before the lang ref. Here's the link to it: https://docs.midnight.network/compact/writing
 
 ### Top-level exports
 


### PR DESCRIPTION
This is an initial restructure of lang-ref.  I did not restructure the syntactic categories yet.  I'm working on a separate PR that gets the grammar snippets and and restructures lang-ref from after the Compact types section.  @dybvig you have the lock on `Overview` section once this is merged.

To catch up lang-ref I'm proposing us merging smaller changes/PRs into `wip/lang-ref-0.21.0` branch and once we're ready merge that into `main`.

