### PR TITLE
Allow CI on fork PRs

### DIFF
--- a/.github/workflows/build-compiler.yml
+++ b/.github/workflows/build-compiler.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: Checkout compactc repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
The license-check CI job fails on PRs from forks because the checkout step explicitly fetches by branch name:

```
ref: ${{ github.head_ref || github.ref_name }}
```

For fork PRs, `github.head_ref` resolves to the branch name on the contributor's fork (e.g., `adam-partial-version-update`). Since `actions/checkout` fetches from origin (this repo), the branch doesn't exist and the fetch fails.

We can remove the explicit `ref:`. When triggered by a `pull_request event`, `actions/checkout` defaults to checking out the merge commit that GitHub automatically creates for every PR (`refs/pull/<number>/merge`). This should work for both same-repo branches and fork PRs.
