### PR TITLE
Fixes type inconsistencies in mintShieldedToken and evolveNonce

### DIFF
--- a/doc/api/CompactStandardLibrary/exports.md
+++ b/doc/api/CompactStandardLibrary/exports.md
@@ -381,7 +381,7 @@ produce this. To mint a shielded token to the current contract, pass
 ```compact
 circuit mintShieldedToken(
   domainSep: Bytes<32>,
-  value: Uint<128>,
+  value: Uint<64>,
   nonce: Bytes<32>,
   recipient: Either<ZswapCoinPublicKey, ContractAddress>
 ): ShieldedCoinInfo;
@@ -394,7 +394,7 @@ and a prior nonce.
 
 ```compact
 circuit evolveNonce(
-  index: Uint<64>,
+  index: Uint<128>,
   nonce: Bytes<32>
 ): Bytes<32>;
 ```


### PR DESCRIPTION
Fixes type inconsistencies in `doc/api/CompactStandardLibrary/exports.md`.

The `mintShieldedToken` function in `standard-library.compact` currently expects `value: Uint<64>`.

These were leftovers from: [PM-16611](https://github.com/LFDT-Minokawa/compact/blob/4c4b52f471b2cd5422c1d3c29e11e0ed643adece/CHANGELOG_compactc.md?plain=1#L717-L722)

I think using `Uint<64>` to represent balances is not ideal. For example, often tokens need high precision (e.g., 18 decimals), `Uint<64>` will overflow. (e.i. 1 ETH = 10^18 wei)

Another suggestion would be to have a type alias `type Balance = Uint<128>;` in the standard library, which would be used everywhere to represent values that are balances.