### PR TITLE
Make it a compiler error to pass opaque JS values to some hash circuits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- It is now a compiler error to pass Compact values containing opaque JS values
+  (`Opaque<'string'>` or `Opaque<'Uint8Array'>`) to the standard library
+  circuits `persistentHash` and `persistentCommit`.  Hashing such values does
+  not work in circuit due to the representation of these types.  Previously,
+  such code would crash the `zkir` process if it tried to generate prover and
+  verifier keys.  Now it is a compiler error instead.
+  
+  This also affects the standard library operation `merkleTreePathRoot` (because
+  it calls `persistentHash` in its implementation), and ledger `MerkleTree`
+  insertion operations, because they implicitly use `persistentHash`.
+  
+  This is a **breaking** change because the error is signaled early, and so it
+  is now an error to use any of these circuits or ADT operations, even for
+  circuits that don't need prover and verifier key generation which would
+  compile successfully before.
+
+## [Unreleased toolchain 0.29.112, language 0.21.101, runtime 0.14.102]
+
+### Changed
+
 - The fixup tool now replaces references to the old standard-library type names
   `CurvePoint` and `NativePoint` with `JubJubPoint`.  It also does a better job
   of renaming standard-library circuits when it is safe to do so and explaining

--- a/compiler/analysis-passes.ss
+++ b/compiler/analysis-passes.ss
@@ -1294,7 +1294,7 @@
         ; ordinary expression types
         (Idtype-Base type)
         ; circuits, witnesses, and statements
-        (Idtype-Function kind arg-name* arg-type* return-type)
+        (Idtype-Function kind is-native arg-name* arg-type* return-type)
         )
       (module (set-idtype! unset-idtype! get-idtype)
         (define ht (make-eq-hashtable))
@@ -1690,6 +1690,14 @@
                expr
                (with-output-language (Ltypes Expression)
                  `(safe-cast ,src ,declared-type ,actual-type ,expr)))]))
+      (define (contains-js-opaque? type)
+        (nanopass-case (Ltypes Type) type
+          [(topaque ,src ,opaque-type) (or (string=? opaque-type "string") (string=? opaque-type "Uint8Array"))]
+          [(tvector ,src ,len ,type) (contains-js-opaque? type)]
+          [(ttuple ,src ,type* ...) (ormap contains-js-opaque? type*)]
+          [(tstruct ,src ,struct-name (,elt-name* ,type*) ...) (ormap contains-js-opaque? type*)]
+          [(talias ,src ,nominal? ,type-name ,type) (contains-js-opaque? type)]
+          [else #f]))
       (define (do-call src fold? fun actual-type* build-call)
         (define compatible-args?
           (let ([nactual (length actual-type*)])
@@ -1700,11 +1708,16 @@
           [(fref ,src^ ,symbolic-function-name ((,function-name** ...) ...)
                  (,generic-value* ...)
                  ((,src* ,generic-kind** ...) ...))
-           (define-record-type blob (nongenerative) (fields name arg-type* return-type))
+           (define-record-type blob (nongenerative) (fields name is-native arg-type* return-type))
            (define (blob<? blob1 blob2)
              (source-object<?
                (id-src (blob-name blob1))
                (id-src (blob-name blob2))))
+           (define (opaque-hashing-error? symbolic-name blob)
+             (and (blob-is-native blob)
+                  (memq symbolic-name '(persistentHash persistentCommit))
+                  (> (length (blob-arg-type* blob)) 0)
+                  (contains-js-opaque? (car (blob-arg-type* blob)))))
            (let outer ([function-name** function-name**] [arg-incompatible-blob** '()] [fold-incompatible-blob** '()])
              (if (null? function-name**)
                  (let ()
@@ -1764,8 +1777,8 @@
                        [function-name** (cdr function-name**)])
                    (let ([blob* (map (lambda (function-name)
                                        (Idtype-case (get-idtype src function-name)
-                                         [(Idtype-Function kind arg-name* arg-type* return-type)
-                                          (make-blob function-name arg-type* return-type)]
+                                         [(Idtype-Function kind is-native arg-name* arg-type* return-type)
+                                          (make-blob function-name is-native arg-type* return-type)]
                                          [else (assert cannot-happen)]))
                                      function-name*)])
                      (let*-values ([(arg-compatible-blob* arg-incompatible-blob*)
@@ -1781,6 +1794,11 @@
                                  (cons fold-incompatible-blob* fold-incompatible-blob**))]
                          [(null? (cdr compatible-blob*))
                           (let ([blob (car compatible-blob*)])
+                            (when (opaque-hashing-error? symbolic-function-name blob)
+                              (source-errorf src
+                                "~a cannot be applied to a first argument containing opaque JavaScript values, received ~a"
+                                symbolic-function-name
+                                (format-type (car (blob-arg-type* blob)))))
                             (build-call
                               (blob-arg-type* blob)
                               (blob-return-type blob)
@@ -2065,11 +2083,17 @@
                 (nanopass-case (Ltypes ADT-Op) (car adt-op*)
                   [(,ledger-op ,op-class ((,var-name* ,type^* ,discloses?*) ...) ,type ,vm-code)
                    (if (eq? ledger-op elt-name)
-                       (begin
-                         (let ([ndeclared (length type^*)] [nactual (length type*)])
-                           (unless (fx= nactual ndeclared)
-                             (source-errorf src "~s ~s requires ~s argument~:*~p but received ~s"
-                                            adt-name ledger-op ndeclared nactual)))
+                       (let ([ndeclared (length type^*)] [nactual (length type*)])
+                         (unless (fx= nactual ndeclared)
+                           (source-errorf src "~a ~a requires ~a argument~:*~p but received ~a"
+                             adt-name ledger-op ndeclared nactual))
+                         (when (and (memq adt-name '(MerkleTree HistoricMerkleTree))
+                                    (memq ledger-op '(insert insertIndex))
+                                    (> nactual 0)
+                                    (contains-js-opaque? (car type*)))
+                           (source-errorf src
+                             "~a ~a cannot be applied to a first argument containing opaque JavaScript values, received ~a"
+                             adt-name ledger-op (format-type (car type*))))
                          (for-each
                            (lambda (declared-type actual-type i)
                              (unless (subtype? actual-type declared-type)
@@ -2083,7 +2107,7 @@
                                                   ledger-op
                                                   (format-type declared-type)
                                                   (format-type actual-type)))))
-                           type^* type* (enumerate type^*))
+                           type^* type* (iota ndeclared))
                          (values
                            (let ([expr* (map (maybe-safecast src) type^* type* expr*)])
                              (with-output-language (Ltypes Expression)
@@ -2148,19 +2172,19 @@
          `(program ,src (,contract-name* ...) ((,export-name* ,name*) ...) ,(maplr Program-Element pelt*) ...))])
     (Set-Program-Element-Type! : Program-Element (ir) -> * (void)
       (definitions
-        (define (build-function kind name arg* type)
+        (define (build-function kind is-native name arg* type)
           (let ([var-name* (map arg->name arg*)] [type* (map arg->type arg*)])
-            (set-idtype! name (Idtype-Function kind var-name* type* type)))))
+            (set-idtype! name (Idtype-Function kind is-native var-name* type* type)))))
       [(circuit ,src ,function-name (,[arg*] ...) ,[Return-Type : type src "circuit" -> type] ,expr)
-       (build-function 'circuit function-name arg* type)]
+       (build-function 'circuit #f function-name arg* type)]
       [(native ,src ,function-name ,native-entry (,[arg*] ...) ,[Return-Type : type src "circuit" -> type])
-       (build-function 'circuit function-name arg* type)]
+       (build-function (native-entry-class native-entry) #t function-name arg* type)]
       [(witness ,src ,function-name (,[arg*] ...) ,[Return-Type : type src "witness" -> type])
        (when (contains-contract? type)
          (source-errorf src "invalid type ~a for witness ~a return value:\n  witness return values cannot include contract values"
                         (format-type type)
                         (id-sym function-name)))
-       (build-function 'witness function-name arg* type)]
+       (build-function 'witness #f function-name arg* type)]
       [(public-ledger-declaration ,src ,ledger-field-name ,[type])
        (unless (public-adt? type)
          (source-errorf src "expected ADT-type for ledger declaration after expand-modules-and-types, received ~a"
@@ -2324,7 +2348,7 @@
       [(var-ref ,src ,var-name)
        (Idtype-case (get-idtype src var-name)
          [(Idtype-Base type) (check-result-type src `(var-ref ,src ,var-name) type)]
-         [(Idtype-Function kind arg-name* arg-type* return-type)
+         [(Idtype-Function kind is-native arg-name* arg-type* return-type)
           ; can't happen if expand-modules-and-types is doing its job
           (source-errorf src "invalid context for reference to ~s name ~s"
                          kind
@@ -2334,7 +2358,7 @@
          `(ledger-ref ,src ,ledger-field-name)
          (Idtype-case (get-idtype src ledger-field-name)
            [(Idtype-Base type) type]
-           [(Idtype-Function kind arg-name* arg-type* return-type)
+           [(Idtype-Function kind is-native arg-name* arg-type* return-type)
             ; can't happen if expand-modules-and-types is doing its job
             (source-errorf src "invalid context for reference to ~s name ~s"
                            kind
@@ -2391,7 +2415,7 @@
          `(var-ref ,src ,var-name)
          (Idtype-case (get-idtype src var-name)
            [(Idtype-Base type) type]
-           [(Idtype-Function kind arg-name* arg-type* return-type)
+           [(Idtype-Function kind is-native arg-name* arg-type* return-type)
             ; can't happen if expand-modules-and-types is doing its job
             (source-errorf src "invalid context for reference to ~s name ~s"
                            kind
@@ -2401,7 +2425,7 @@
          `(ledger-ref ,src ,ledger-field-name)
          (Idtype-case (get-idtype src ledger-field-name)
            [(Idtype-Base type) type]
-           [(Idtype-Function kind arg-name* arg-type* return-type)
+           [(Idtype-Function kind is-native arg-name* arg-type* return-type)
             ; can't happen if expand-modules-and-types is doing its job
             (source-errorf src "invalid context for reference to ~s name ~s"
                            kind

--- a/compiler/compiler-version.ss
+++ b/compiler/compiler-version.ss
@@ -20,7 +20,7 @@
   (import (chezscheme) (version))
 
   ; NB: also update compactc version in ../flake.nix
-  (define compiler-version (make-version 'compiler 0 29 112))
+  (define compiler-version (make-version 'compiler 0 29 113))
 
   (define compiler-version-string (make-version-string compiler-version))
 

--- a/compiler/test.ss
+++ b/compiler/test.ss
@@ -23838,6 +23838,120 @@ groups than for single tests.
         (export-typedef SY (T)
           (tstruct SY (curidx (tunsigned 0))))))
     )
+
+    (test
+    '(
+      "import CompactStandardLibrary;"
+      "ledger hash: Bytes<32>;"
+      "export circuit fisk(msg: Opaque<'string'>): [] {"
+      "  hash = disclose(persistentHash<Opaque<'string'>>(msg));"
+      "}"
+      )
+    (oops
+      message: "~a:\n  ~?"
+      irritants: '("testfile.compact line 4 char 19" "~a cannot be applied to a first argument containing opaque JavaScript values, received ~a" (persistentHash "Opaque<\"string\">")))
+    )
+    (test
+    '(
+      "import CompactStandardLibrary;"
+      "ledger hash: Bytes<32>;"
+      "export circuit fisk(arr: Opaque<'Uint8Array'>): [] {"
+      "  hash = disclose(persistentHash<Opaque<'Uint8Array'>>(arr));"
+      "}"
+      )
+    (oops
+      message: "~a:\n  ~?"
+      irritants: '("testfile.compact line 4 char 19" "~a cannot be applied to a first argument containing opaque JavaScript values, received ~a" (persistentHash "Opaque<\"Uint8Array\">")))
+    )
+    (test
+    '(
+      "import CompactStandardLibrary;"
+      "ledger hash: Bytes<32>;"
+      "struct LabeledField {"
+      "  label: Opaque<'string'>;"
+      "  field: Field;"
+      "}"
+      "export circuit fisk(lf: LabeledField): [] {"
+      "  hash = disclose(persistentHash<LabeledField>(lf));"
+      "}"
+      )
+    (oops
+      message: "~a:\n  ~?"
+      irritants: '("testfile.compact line 8 char 19" "~a cannot be applied to a first argument containing opaque JavaScript values, received ~a" (persistentHash "struct LabeledField<label: Opaque<\"string\">, field: Field>")))
+    )
+    (test
+    '(
+      "import CompactStandardLibrary;"
+      "ledger hash: Bytes<32>;"
+      "export circuit fisk(msgs: Vector<10, Opaque<'string'>>): [] {"
+      "  hash = disclose(persistentHash<Vector<10, Opaque<'string'>>>(msgs));"
+      "}"
+      )
+    (oops
+      message: "~a:\n  ~?"
+      irritants: '("testfile.compact line 4 char 19" "~a cannot be applied to a first argument containing opaque JavaScript values, received ~a" (persistentHash "Vector<10, Opaque<\"string\">>")))
+    )
+    (test
+    '(
+      "import CompactStandardLibrary;"
+      "ledger hash: Bytes<32>;"
+      "new type Messages = Vector<10, Opaque<'string'>>;"
+      "export circuit fisk(msgs: Messages): [] {"
+      "  hash = disclose(persistentHash<Messages>(msgs));"
+      "}"
+      )
+    (oops
+      message: "~a:\n  ~?"
+      irritants: '("testfile.compact line 5 char 19" "~a cannot be applied to a first argument containing opaque JavaScript values, received ~a" (persistentHash "Messages")))
+    )
+    (test
+    '(
+      "import CompactStandardLibrary;"
+      "ledger hash: Bytes<32>;"
+      "export circuit fisk(msg: Opaque<'string'>): [] {"
+      "  hash = disclose(persistentCommit<Opaque<'string'>>(msg, hash));"
+      "}"
+      )
+    (oops
+      message: "~a:\n  ~?"
+      irritants: '("testfile.compact line 4 char 19" "~a cannot be applied to a first argument containing opaque JavaScript values, received ~a" (persistentCommit "Opaque<\"string\">")))
+    )
+    (test
+    '(
+      "import CompactStandardLibrary;"
+      "ledger mt: MerkleTree<10, Opaque<'string'>>;"
+      "export circuit fisk(msg: Opaque<'string'>): [] {"
+      "  mt.insert(disclose(msg));"
+      "}"
+      )
+    (oops
+      message: "~a:\n  ~?"
+      irritants: '("testfile.compact line 4 char 5" "~a ~a cannot be applied to a first argument containing opaque JavaScript values, received ~a" (MerkleTree insert "Opaque<\"string\">")))
+    )
+    (test
+    '(
+      "import CompactStandardLibrary;"
+      "ledger mt: MerkleTree<10, Opaque<'string'>>;"
+      "export circuit fisk(msg: Opaque<'string'>): [] {"
+      "  mt.insertIndex(disclose(msg), 21);"
+      "}"
+      )
+    (oops
+      message: "~a:\n  ~?"
+      irritants: '("testfile.compact line 4 char 5" "~a ~a cannot be applied to a first argument containing opaque JavaScript values, received ~a" (MerkleTree insertIndex "Opaque<\"string\">")))
+    )
+    (test
+    '(
+      "import CompactStandardLibrary;"
+      "ledger mt: HistoricMerkleTree<10, Opaque<'string'>>;"
+      "export circuit fisk(msg: Opaque<'string'>): [] {"
+      "  mt.insert(disclose(msg));"
+      "}"
+      )
+    (oops
+      message: "~a:\n  ~?"
+      irritants: '("testfile.compact line 4 char 5" "~a ~a cannot be applied to a first argument containing opaque JavaScript values, received ~a" (HistoricMerkleTree insert "Opaque<\"string\">")))
+    )
 )
 
 ; tests limits for vectors, bytes, and tuples.
@@ -25185,7 +25299,7 @@ groups than for single tests.
       )
     (oops
       message: "~a:\n  ~?"
-      irritants: '("testfile.compact line 4 char 37" "~s ~s requires ~s argument~:*~p but received ~s" (__compact_Cell write 1 0)))
+      irritants: '("testfile.compact line 4 char 37" "~a ~a requires ~a argument~:*~p but received ~a" (__compact_Cell write 1 0)))
     )
 
   (test
@@ -25197,7 +25311,7 @@ groups than for single tests.
       )
     (oops
       message: "~a:\n  ~?"
-      irritants: '("testfile.compact line 4 char 44" "~s ~s requires ~s argument~:*~p but received ~s" (__compact_Cell read 0 1)))
+      irritants: '("testfile.compact line 4 char 44" "~a ~a requires ~a argument~:*~p but received ~a" (__compact_Cell read 0 1)))
     )
 
   (test
@@ -25221,7 +25335,7 @@ groups than for single tests.
       )
     (oops
       message: "~a:\n  ~?"
-      irritants: '("testfile.compact line 4 char 37" "~s ~s requires ~s argument~:*~p but received ~s" (__compact_Cell write 1 2)))
+      irritants: '("testfile.compact line 4 char 37" "~a ~a requires ~a argument~:*~p but received ~a" (__compact_Cell write 1 2)))
     )
 
   (test
@@ -55592,7 +55706,7 @@ groups than for single tests.
       "}"
       ""
       "export circuit three(): [S, Bytes<32>] {"
-      "  return [field0, persistentHash<Opaque<'string'>>(field1)];"
+      "  return [field0, persistentHash<S>(field0)];"
       "}"
      )
     (succeeds)
@@ -62692,7 +62806,7 @@ groups than for single tests.
       "}"
       ""
       "export circuit three(): [S, Bytes<32>] {"
-      "  return [field0, persistentHash<Opaque<'string'>>(field1)];"
+      "  return [field0, persistentHash<S>(field0)];"
       "}"
      )
     (succeeds)

--- a/doc/ledger-adt.mdx
+++ b/doc/ledger-adt.mdx
@@ -1,6 +1,6 @@
 # Ledger data types
 
-Compact language version 0.21.101, compiler version 0.29.112.
+Compact language version 0.21.101, compiler version 0.29.113.
 
 ## Kernel
 

--- a/flake.nix
+++ b/flake.nix
@@ -220,7 +220,7 @@
 
           packages.compactc = pkgs.stdenv.mkDerivation {
             name = "compactc";
-            version = "0.29.112"; # NB: also update compiler-version in compiler/compiler-version.ss
+            version = "0.29.113"; # NB: also update compiler-version in compiler/compiler-version.ss
             src = inclusive.lib.inclusive ./. [
               ./compiler
               ./examples


### PR DESCRIPTION
The JS opaque values of type `string` and `Uint8Array` are represented in circuit by a hash of their contents, not the (variable-sized) contents themselves.  As a consequence, the standard library `persistentHash` function does not work for them---it is impossible to compute the same hash value in circuit that was computed off circuit.

`persistentCommit` and some ledger `MerkleTree` operations are similarly affected, because they use `persistentHash` on user supplied data.

Previously, these circuits would fail with a crash during key generation.  This change makes it a compiler error instead.