### PR TITLE
Add checkout step to `publish-test-results` workflow

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -52,6 +52,9 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Initialize git repository
+        run: git init
+
       # dorny/test-reporter: Creates a GitHub check run with a summary of
       # test results parsed from JUnit XML reports.
       - name: Publish Test Report


### PR DESCRIPTION
Add `git init` step to the publish-test-results workflow so that `dorny/test-reporter` can run `git ls-files` without crashing

Should address #217 