### PR TITLE
Move inline test reporting to publish-test-results workflow

### DIFF
--- a/.github/workflows/build-vscplugin.yml
+++ b/.github/workflows/build-vscplugin.yml
@@ -32,23 +32,25 @@ jobs:
           yarn compile
           yarn test
 
-      - name: Publish Test Report
-        uses: dorny/test-reporter@3d76b34a4535afbd0600d347b09a6ee5deb3ed7f # v2.6.0
+      # Test result artifacts are consumed by the "Publish Test Results"
+      # workflow (publish-test-results.yml) which runs with write permissions
+      # via the workflow_run trigger. This two-workflow pattern is necessary
+      # so that fork/Dependabot PRs can have test results posted as PR comments.
+      - name: Upload Junit test results
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
-          name: Plugin JEST Tests Report
-          path: |
-            !(node_modules)/**/reports/test-report.xml
-          reporter: jest-junit
+          name: test-results-junit-summary
+          path: editor-support/vsc/compact/reports/test-report.xml
 
-      - name: Publish Test Summary
-        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
+      # The event file is needed by the reporting workflow to associate
+      # test results with the correct PR.
+      - name: Upload event file
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
-          check_name: Plugin Test Results
-          files: |
-            **/reports/test-report.xml
-            !(node_modules)/**/test-report.xml
+          name: event-file
+          path: ${{ github.event_path }}
 
       - name: Upload Coverage Report Artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/compiler-extracted.yml
+++ b/.github/workflows/compiler-extracted.yml
@@ -50,31 +50,30 @@ jobs:
           nix develop .#compiler --command yarn install
           nix develop .#compiler --command yarn test:extracted
 
-      - name: Publish Test Report
-        uses: dorny/test-reporter@3d76b34a4535afbd0600d347b09a6ee5deb3ed7f # v2.6.0
+      # Test result artifacts are consumed by the "Publish Test Results"
+      # workflow (publish-test-results.yml) which runs with write permissions
+      # via the workflow_run trigger. This two-workflow pattern is necessary
+      # so that fork/Dependabot PRs can have test results posted as PR comments.
+      - name: Upload CTRF test results
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
-          name: Compactc E2E Tests Report
-          path: |
-            !(node_modules)/**/reports/test-report.xml
-          reporter: jest-junit
+          name: test-results-ctrf-summary
+          path: tests-e2e/reports/ctrf-report.json
 
-      - name: Publish Test Summary
-        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
+      - name: Upload Junit test results
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
-          check_name: Compactc E2E Tests Results
-          files: |
-            **/reports/test-report.xml
-            !(node_modules)/**/test-report.xml
+          name: test-results-junit-summary
+          path: tests-e2e/reports/test-report.xml
 
-      - name: Publish Test Summary Results
-        uses: ctrf-io/github-test-reporter@024bc4b64d997ca9da86833c6b9548c55c620e40 # v1.0.26
+      # The event file is needed by the reporting workflow to associate
+      # test results with the correct PR.
+      - name: Upload event file
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: always()
         with:
-          report-path: 'tests-e2e/reports/ctrf-report.json'
-          flaky-rate-report: 'true'
-          pull-request: 'true'
-          update-comment: 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: event-file
+          path: ${{ github.event_path }}
 

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -1,5 +1,4 @@
-# Publishes test results from the "Compiler Build" workflow as PR comments
-# and check runs.
+# Publishes test results from build workflows as PR comments and check runs.
 #
 # This is a separate workflow because fork PRs run with a read-only
 # GITHUB_TOKEN, which prevents the build workflow from posting comments
@@ -12,7 +11,7 @@ name: Publish Test Results
 
 on:
   workflow_run:
-    workflows: ["Compiler Build"]
+    workflows: ["Compiler Build", "Compiler extracted", "VSC Plugin Build"]
     types:
       - completed
 
@@ -38,6 +37,7 @@ jobs:
 
       - name: Download CTRF test results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        if: github.event.workflow_run.name != 'VSC Plugin Build'
         with:
           name: test-results-ctrf-summary
           path: artifacts/ctrf
@@ -52,35 +52,50 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set check names
+        id: names
+        run: |
+          case "${{ github.event.workflow_run.name }}" in
+            "VSC Plugin Build")
+              echo "report_name=Plugin Test Report" >> "$GITHUB_OUTPUT"
+              echo "summary_name=Plugin Test Summary" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "report_name=Compactc E2E Test Report" >> "$GITHUB_OUTPUT"
+              echo "summary_name=Compactc E2E Test Summary" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
       - name: Initialize git repository
         run: git init
 
-      # dorny/test-reporter: Creates a GitHub check run with a summary of
-      # test results parsed from JUnit XML reports.
+      # dorny/test-reporter: Creates a GitHub check run with a detailed,
+      # browsable report of individual test cases from JUnit XML.
       - name: Publish Test Report
         uses: dorny/test-reporter@3d76b34a4535afbd0600d347b09a6ee5deb3ed7f # v2.6.0
         with:
-          name: Compactc E2E Tests Report
+          name: ${{ steps.names.outputs.report_name }}
           path: artifacts/junit/test-report.xml
           reporter: jest-junit
 
       # EnricoMi/publish-unit-test-result-action: Creates a check run and
-      # posts a PR comment with detailed test counts (pass/fail/skip).
+      # posts a PR comment with aggregated test counts (pass/fail/skip).
       # The commit, event_file, and event_name inputs are required for
       # workflow_run to associate results with the correct PR.
       - name: Publish Test Summary
         uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         with:
-          check_name: Compactc E2E Tests Results
+          check_name: ${{ steps.names.outputs.summary_name }}
           files: artifacts/junit/test-report.xml
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/event/event.json
           event_name: ${{ github.event.workflow_run.event }}
 
       # github-actions-ctrf: Posts a CTRF-format test summary to the
-      # Actions run and as a PR comment.
+      # Actions run and as a PR comment. Only compactc workflows produce
+      # CTRF reports.
       - name: Publish CTRF Summary
-        if: always()
+        if: always() && github.event.workflow_run.name != 'VSC Plugin Build'
         run: |
           npx github-actions-ctrf artifacts/ctrf/ctrf-report.json --title "E2E test results"
           npx github-actions-ctrf pull-request artifacts/ctrf/ctrf-report.json --title "E2E test results"


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                        
  - Moved inline test reporting steps out of `compiler-extracted.yml` and `build-vscplugin.yml` into the existing `publish-test-results.yml` workflow                                                                                                                               
  - Both workflows now upload test result artifacts instead of publishing directly, matching the pattern already established in `build-compiler.yml`                                                                                                                                
  - `publish-test-results.yml` now triggers on all three build workflows and sets check names dynamically based on which workflow produced the results                                                                                                                              
                                                                                                                                                                                                                                                                                    
  ## Context                                                                                                                                                                                                                                                                        
  Dependabot PRs (and fork PRs) run with a read-only `GITHUB_TOKEN`, which causes inline calls to `dorny/test-reporter` and `EnricoMi/publish-unit-test-result-action` to fail with a 403 when trying to create check runs. This was already solved for the "Compiler Build"        
  workflow by routing reporting through `publish-test-results.yml` via `workflow_run`, but "Compiler extracted" and "VSC Plugin Build" still had the reporting steps inline.                                                                                                        
                                                                                                                                                                                                                                                                                    
  Spotted via https://github.com/LFDT-Minokawa/compact/actions/runs/23281101465/job/67694635438?pr=228 and https://github.com/LFDT-Minokawa/compact/actions/runs/23281101479/job/67694635514?pr=228.