### PR TITLE
Bump the devtools version in preparation for releasing 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,7 +570,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compact"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "axoupdater",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ resolver = "3"
 members = ["tools/*"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Midnight Foundation"]
 edition = "2024"
 rust-version = "1.88.0"

--- a/tools/compact/CHANGELOG.md
+++ b/tools/compact/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [Compact tools 0.5.1]
+
+### Fixed
+
+- A bug that prevented ARM Linux builds from being installed.  There was already
+  a toolchain release `.zip` file for this platform (since toolchain version
+  0.29.0), but the platform was not recognized by the command-line tools.
+  
+  Fixes issue #222.
+
 ## [Compact tools 0.5.0]
 
 ### Added


### PR DESCRIPTION
This is a bug fix release to include the fix to allow ARM Linux to be installed via the devtools.