### PR TITLE
Update the devtools tests for the 0.5.1 release

### DIFF
--- a/tools/compact/tests/common/mod.rs
+++ b/tools/compact/tests/common/mod.rs
@@ -19,10 +19,10 @@ use std::process::Command;
 use std::{fs, io};
 
 #[allow(dead_code)]
-pub const COMPACT_VERSION: &str = "0.5.0";
+pub const COMPACT_VERSION: &str = "0.5.1";
 
 #[allow(dead_code)]
-pub const PREVIOUS_COMPACT_VERSION: &str = "0.4.0";
+pub const PREVIOUS_COMPACT_VERSION: &str = "0.5.0";
 
 #[allow(dead_code)]
 pub const LATEST_COMPACTC_VERSION: &str = "0.30.0";


### PR DESCRIPTION
Devtools 0.5.1 has just been released, the `self` tests need to reflect the updated version numbers.