### PR TITLE
Add equality for JubjubPoint to TypeScript code generator

### DIFF
--- a/compiler/test.ss
+++ b/compiler/test.ss
@@ -66417,6 +66417,32 @@ groups than for single tests.
         ))
     )
 
+  ; GitHub issue #278: JubjubPoint equality should be component-wise, not reference equality
+  (test
+    '(
+      "import CompactStandardLibrary;"
+      "export circuit pointsEqual(a: JubjubPoint, b: JubjubPoint): Boolean {"
+      "  return a == b;"
+      "}"
+      "export circuit pointsNotEqual(a: JubjubPoint, b: JubjubPoint): Boolean {"
+      "  return a != b;"
+      "}"
+      )
+    (stage-javascript
+      '(
+        "test('JubjubPoint equality', () => {"
+        "  const [C, Ctxt] = startContract(contractCode, {}, 0);"
+        "  const p1 = runtime.ecMulGenerator(5n);"
+        "  const p2 = runtime.ecMulGenerator(5n);"
+        "  const p3 = runtime.ecMulGenerator(7n);"
+        "  expect(C.circuits.pointsEqual(Ctxt, p1, p2).result).toEqual(true);"
+        "  expect(C.circuits.pointsEqual(Ctxt, p1, p3).result).toEqual(false);"
+        "  expect(C.circuits.pointsNotEqual(Ctxt, p1, p2).result).toEqual(false);"
+        "  expect(C.circuits.pointsNotEqual(Ctxt, p1, p3).result).toEqual(true);"
+        "  });"
+        ))
+    )
+
  (with-compact-path '(".")
   (test
     '(

--- a/compiler/typescript-passes.ss
+++ b/compiler/typescript-passes.ss
@@ -2744,6 +2744,22 @@
                          (printf "}\n"))
                        elt-name*
                        type*)]
+                    [(topaque ,src ,opaque-type)
+                     (guard (string=? opaque-type "JubjubPoint"))
+                     (for-each
+                       (lambda (elt-name)
+                         (print-indent indent)
+                         (printf "{\n")
+                         (let ([next-i (fx+ i 1)] [next-indent (fx+ indent 2)])
+                           (print-indent next-indent)
+                           (printf "let x~s = x~s.~s;\n" next-i i elt-name)
+                           (print-indent next-indent)
+                           (printf "let y~s = y~s.~s;\n" next-i i elt-name)
+                           (print-indent next-indent)
+                           (printf "if (x~s !== y~:*~s) { return false; }\n" next-i))
+                         (print-indent indent)
+                         (printf "}\n"))
+                       '(x y))]
                     [else
                      (print-indent indent)
                      (printf "if (x~s !== y~:*~s) { return false; }\n" i)])))))
@@ -2928,7 +2944,7 @@
        (if (nanopass-case (Ltypescript Type) (de-alias type)
              [(tboolean ,src) #t]
              [(tfield ,src) #t]
-             [(topaque ,src ,opaque-type) #t]
+             [(topaque ,src ,opaque-type) (not (string=? opaque-type "JubjubPoint"))]
              [(tenum ,src ,enum-name ,elt-name ,elt-name* ...) #t]
              [else #f])
            (parenthesize level (precedence ==)
@@ -2951,7 +2967,7 @@
        (if (nanopass-case (Ltypescript Type) (de-alias type)
              [(tboolean ,src) #t]
              [(tfield ,src) #t]
-             [(topaque ,src ,opaque-type) #t]
+             [(topaque ,src ,opaque-type) (not (string=? opaque-type "JubjubPoint"))]
              [(tenum ,src ,enum-name ,elt-name ,elt-name* ...) #t]
              [else #f])
            (parenthesize level (precedence ==)


### PR DESCRIPTION
Fixes #278 

When `JubjubPoint` was changed from a Compact struct to a builtin opaque type, the TypeScript backend started emitting `===` / `!==` for equality checks. This is reference equality — two `JubjubPoint` objects with identical `x` and `y` coordinates compare as not equal if they're different JS objects. The ZKIR backend was unaffected since it correctly flattens opaque types to their component fields.

The fix excludes `JubjubPoint` from the branch in `typescript-passes.ss` where opaque types get `===` for equality, so it falls through to `build-equal-helper!` instead. A new `topaque` case in that helper generates field-by-field comparison of `.x` and `.y`, matching what the ZKIR backend already does. A guard clause ensures only `JubjubPoint` takes this path; other opaque types (e.g. `string`, `Uint8Array`) still use `===` as before.