### PR TITLE
Composable contracts flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ plonk-napi/pkg
 *.node
 
 *.mdb
+*.so
 .direnv
 
 # nix result

--- a/compiler/compactc.ss
+++ b/compiler/compactc.ss
@@ -77,6 +77,11 @@ The following flags, if present, affect the compiler's behavior as follows:
   --trace-search causes the compiler to print a sequence of messages saying
     where it is looking for each included file and imported module source file.
 
+  --feature-cross-contract enables experimental cross-contract call support.
+    When set, the compiler will emit warnings instead of errors for cross-
+    contract calls in ZKIR and TypeScript passes.  This flag implies
+    --feature-zkir-v3.
+
   --trace-passes causes the compiler to print tracing information that is
     generally useful only to compiler developers.
 "))
@@ -97,7 +102,8 @@ The following flags, if present, affect the compiler's behavior as follows:
              [(--compact-path) (string search-list)]
              [(--trace-search)]
              [(--trace-passes)]
-             [(--feature-zkir-v3)])
+             [(--feature-zkir-v3)]
+             [(--feature-cross-contract)])
       (string source-pathname)
       (string target-directory-pathname))
      (check-pathname source-pathname)
@@ -105,7 +111,8 @@ The following flags, if present, affect the compiler's behavior as follows:
      (parameterize ([trace-passes ?--trace-passes]
                     [skip-zk ?--skip-zk]
                     [no-communications-commitment ?--no-communications-commitment]
-                    [feature-zkir-v3 ?--feature-zkir-v3]
+                    [feature-zkir-v3 (or ?--feature-zkir-v3 ?--feature-cross-contract)]
+                    [feature-cross-contract ?--feature-cross-contract]
                     [compact-path (if ?--compact-path (split-search-path search-list) (compact-path))]
                     [trace-search ?--trace-search])
        (when source-root (register-source-root! source-root))
@@ -116,7 +123,8 @@ The following flags, if present, affect the compiler's behavior as follows:
              [(--language-version) $ (begin (print-language-version) (exit))]
              [(--ledger-version) $ (begin (print-ledger-version ?--feature-zkir-v3) (exit))]
              [(--runtime-version) $ (begin (print-runtime-version) (exit))]
-             [(--feature-zkir-v3)])
+             [(--feature-zkir-v3)]
+             [(--feature-cross-contract)])
       (string arg) ...)
      (print-usage #t)
      (exit 1)]))

--- a/compiler/config-params.ss
+++ b/compiler/config-params.ss
@@ -41,4 +41,5 @@
 
   ; feature flags
   (export-parameter feature-zkir-v3 #f)
+  (export-parameter feature-cross-contract #f)
 )

--- a/compiler/test.ss
+++ b/compiler/test.ss
@@ -66070,6 +66070,60 @@ groups than for single tests.
 
   )
 
+(parameterize ([feature-cross-contract #t] [feature-zkir-v3 #t])
+(run-tests print-zkir-v3
+  (test-group
+    ((create-file "Calc.compact"
+       '(
+         "import CompactStandardLibrary;"
+         "export circuit get_value(): Field { return 42; }"
+         ))
+     (succeeds))
+    ((create-file "UseCalc.compact"
+       '(
+         "import CompactStandardLibrary;"
+         "contract Calc {"
+         "  pure circuit get_value(): Field;"
+         "}"
+         "ledger c: Calc;"
+         "constructor (addr: Calc) { c = disclose(addr); }"
+         "export circuit call_calc(): Field { return c.get_value(); }"
+         ))
+     (succeeds)
+     (warning
+       message: "~a:\n  ~?"
+       irritants: '("UseCalc.compact line 7 char 45" "cross-contract call skipped (experimental cross-contract support)" ()))
+     ))
+  ))
+
+(parameterize ([feature-cross-contract #t] [feature-zkir-v3 #t])
+(run-tests print-typescript
+  (test-group
+    ((create-file "Calc.compact"
+       '(
+         "import CompactStandardLibrary;"
+         "export circuit get_value(): Field { return 42; }"
+         ))
+     (succeeds))
+    ((create-file "UseCalc.compact"
+       '(
+         "import CompactStandardLibrary;"
+         "contract Calc {"
+         "  pure circuit get_value(): Field;"
+         "}"
+         "ledger c: Calc;"
+         "constructor (addr: Calc) { c = disclose(addr); }"
+         "export circuit call_calc(): Field { return c.get_value(); }"
+         ))
+     (succeeds)
+     (warning
+       message: "~a:\n  ~?"
+       irritants: '("UseCalc.compact line 7 char 45" "cross-contract call skipped (experimental cross-contract support)" ())
+       message: "~a:\n  ~?"
+       irritants: '("UseCalc.compact line 7 char 45" "cross-contract call stubbed (experimental cross-contract support)" ()))
+     ))
+  ))
+
 (with-parameter-values ([feature-zkir-v3 #f #t])
 (run-tests print-typescript
   (test-group

--- a/compiler/typescript-passes.ss
+++ b/compiler/typescript-passes.ss
@@ -27,7 +27,8 @@
           (runtime-version)
           (ledger)
           (vm)
-          (sourcemaps))
+          (sourcemaps)
+          (config-params))
 
   (define-pass prepare-for-typescript : Lnodisclose (ir) -> Ltypescript ()
     (definitions
@@ -3217,7 +3218,9 @@
             (let ([q (construct-query src path-elt* adt-formal* adt-arg* adt-op expr*)])
               (nanopass-case (Ltypescript Type) (de-alias type)
                 [(tcontract ,src ,contract-name (,elt-name* ,pure-dcl* (,type** ...) ,type*) ...)
-                 (assert not-implemented)]
+                 (if (feature-cross-contract)
+                     q
+                     (assert not-implemented))]
                 [else
                  (if descriptor-name?
                      (make-Qconcat
@@ -3227,7 +3230,11 @@
                        ".value)")
                      q)])))])]
       [(contract-call ,src ,elt-name (,[Expr : expr (precedence add1 comma) outer-pure? -> * expr] ,type) ,[Expr : expr* (precedence add1 comma) outer-pure? -> * expr*] ...)
-       (source-errorf src "contract types are not yet implemented")])
+       (if (feature-cross-contract)
+           (begin
+             (source-warningf src "cross-contract call stubbed (experimental cross-contract support)")
+             "undefined")
+           (source-errorf src "contract types are not yet implemented"))])
     (Map-Argument : Map-Argument (ir level outer-pure?) -> * (Q byte-ref?)
       [(,[Expr : expr (precedence add1 comma) outer-pure? -> * expr] ,type ,type^)
        (values

--- a/compiler/zkir-v3-passes.ss
+++ b/compiler/zkir-v3-passes.ss
@@ -663,7 +663,11 @@
          (assert code-generator)
          (code-generator var-name* src test triv* instr*))]
       [(= (,var-name* ...) (contract-call ,src ,test ,elt-name (,triv ,primitive-type) ,triv* ...))
-       (source-errorf src "cross-contract calls are not yet supported")]
+       (if (feature-cross-contract)
+           (begin
+             (source-warningf src "cross-contract call skipped (experimental cross-contract support)")
+             instr*)
+           (source-errorf src "cross-contract calls are not yet supported"))]
       [(= (,var-name) (default ,opaque-type))
        (assert (string=? opaque-type "JubjubPoint"))
        (with-output-language (Lzkir Instruction)


### PR DESCRIPTION
 Adds an experimental --feature-cross-contract compiler flag that unblocks end-to-end compilation of contracts using cross-contract calls. Prior to this change, the ZKIR   v3 and TypeScript backends hard-error the moment they encounter a contract-call node, so composability couldn't even be exercised against the full pipeline. Under the   new flag, those errors become warnings and the offending nodes are skipped (ZKIR) or stubbed as undefined (TypeScript), letting downstream work on composability iterate   without constantly patching the compiler.

  This is intentionally a scaffold — it does not implement real cross-contract proof composition. It implies --feature-zkir-v3 since composability only targets the v3   backend; the v2 backend keeps its hard error.

  Changes

  Compiler flag plumbing
  - compiler/config-params.ss: new feature-cross-contract parameter (default #f).
  - compiler/compactc.ss: new --feature-cross-contract CLI flag, help text, and parameterize. The flag implies --feature-zkir-v3 at the CLI layer ((or ?--feature-zkir-v3   ?--feature-cross-contract)).

  ZKIR v3 pass (compiler/zkir-v3-passes.ss)
  - Gates the existing "cross-contract calls are not yet supported" error on the contract-call Statement handler. Under the flag, it emits a source-warningf   ("cross-contract call skipped") and drops the instruction, letting the rest of the circuit lower cleanly.

  TypeScript pass (compiler/typescript-passes.ss)
  - Imports config-params for flag access.
  - Gates the tcontract query-construction assert not-implemented on ledger reads — under the flag, the query is passed through unchanged.
  - Gates the contract-call expression error — under the flag, emits source-warningf ("cross-contract call stubbed") and substitutes the literal string "undefined" for the   call expression.

  Tests (compiler/test.ss)
  - Two new run-tests groups, both parameterized with feature-cross-contract #t and feature-zkir-v3 #t (since the implication only exists at the CLI layer, not in the   compiler params themselves).
  - Two-file fixture: Calc.compact (dependency exporting get_value) + UseCalc.compact (caller declaring contract Calc, a ledger c: Calc, a constructor that stores the   disclosed address, and a circuit that calls c.get_value()).
  - ZKIR group: asserts the skip warning fires on line 7 char 45.
  - TypeScript group: asserts both warnings fire (the ZKIR skip and the TS stub), since print-typescript runs the full pipeline.

  Misc
  - .gitignore: ignore *.so files.

  Non-goals / What this PR deliberately does NOT do

  - Does not emit any real constraints for cross-contract calls in ZKIR.
  - Does not generate working JS for cross-contract calls — the call site becomes undefined.
  - Does not re-enable the 5 disabled ; FIXME uncomment composable contract tests in compiler/test.ss.
  - Does not touch the ZKIR v2 backend.
  - Does not change any default behavior: without the flag, compilation still hard-errors exactly as before.
  
    Test plan

  All verification runs via the standard nix-wired path — nix build .#compactc, whose checkPhase invokes ./compiler/go and exercises the full compiler/test.ss suite   (including the two new groups added here).

  - nix build .#compactc succeeds — the new ZKIR v3 and TypeScript groups for --feature-cross-contract pass alongside the existing suite, with no regressions in any other   group
  - nix build .#compactc-binary-nixos succeeds — confirms the flag wiring in compactc.ss compiles cleanly under the release build path as well
  - nix flake check is green