### PR TITLE
[Issue 330] fix failure of scheduled internal release

### DIFF
--- a/.github/actions/setup-nix-cache/action.yml
+++ b/.github/actions/setup-nix-cache/action.yml
@@ -4,7 +4,12 @@ description: Install Nix, configure Attic cache, and make the cache hook non-fat
 inputs:
   attic_token:
     description: Attic cache access token
-    required: true
+    required: false
+    default: ''
+  skip_cache:
+    description: Skip Attic cache configuration
+    required: false
+    default: 'false'
   nix_path:
     description: Nix path channel
     default: nixpkgs=channel:nixos-unstable
@@ -25,7 +30,8 @@ runs:
         extra_nix_config: ${{ inputs.extra_nix_config }}
 
     - name: Cache Nix
-      uses: input-output-hk/actions/attic@8663542d03a41382d97ee344a4e3955280db5f95 # latest
+      if: ${{ inputs.skip_cache != 'true' }}
+      uses: input-output-hk/actions/attic@8663542d03a41382d97ee344a4e3955280db5f95
       continue-on-error: true
       with:
         nix_path: ${{ inputs.nix_path }}
@@ -33,8 +39,8 @@ runs:
         cache: midnight-public
         access_token: ${{ inputs.attic_token }}
 
-    # TODO: Fix upstream in input-output-hk/actions/attic or replace Attic.
     - name: Make cache hook non-fatal
+      if: ${{ inputs.skip_cache != 'true' }}
       shell: bash
       env:
         HOOK: ${{ runner.temp }}/post-build.sh

--- a/.github/actions/setup-nix-cache/action.yml
+++ b/.github/actions/setup-nix-cache/action.yml
@@ -31,7 +31,7 @@ runs:
 
     - name: Cache Nix
       if: ${{ inputs.skip_cache != 'true' }}
-      uses: input-output-hk/actions/attic@8663542d03a41382d97ee344a4e3955280db5f95
+      uses: input-output-hk/actions/attic@8663542d03a41382d97ee344a4e3955280db5f95 # latest
       continue-on-error: true
       with:
         nix_path: ${{ inputs.nix_path }}
@@ -39,6 +39,7 @@ runs:
         cache: midnight-public
         access_token: ${{ inputs.attic_token }}
 
+    # TODO: Fix upstream in input-output-hk/actions/attic or replace Attic.
     - name: Make cache hook non-fatal
       if: ${{ inputs.skip_cache != 'true' }}
       shell: bash

--- a/.github/workflows/internal-release.yml
+++ b/.github/workflows/internal-release.yml
@@ -98,7 +98,7 @@ jobs:
         id: macos_arm
         run: echo "name=aarch64-darwin" >> "$GITHUB_OUTPUT"
 
-      - name: Set linux x86 name
+      - name: Set macos x86 name
         id: macos_x86
         run: echo "name=x86_64-darwin" >> "$GITHUB_OUTPUT"
 
@@ -244,7 +244,7 @@ jobs:
       skipCache: true
 
   test-arm-linux:
-    name: Test compactc on Linux aarch42 (Arm)
+    name: Test compactc on Linux aarch64 (Arm)
     uses: ./.github/workflows/release-test.yml
     needs: [ setup, build-release-arm-linux ]
     permissions:

--- a/.github/workflows/internal-release.yml
+++ b/.github/workflows/internal-release.yml
@@ -107,9 +107,13 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          # Extract just the major.minor.patch part (strip leading 'v' and any suffix like -rc.0)
-          CLEAN_VERSION=$(echo "$VERSION" | sed 's/^v//' | sed 's/-.*//')
-          echo "file=doc/release-notes/toolchain-${CLEAN_VERSION}.md" >> "$GITHUB_OUTPUT"
+          if [ -n "$VERSION" ]; then
+            # Extract just the major.minor.patch part (strip leading 'v' and any suffix like -rc.0)
+            CLEAN_VERSION=$(echo "$VERSION" | sed 's/^v//' | sed 's/-.*//')
+            echo "file=doc/release-notes/toolchain-${CLEAN_VERSION}.md" >> "$GITHUB_OUTPUT"
+          else
+            echo "file=" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set release notes include flag
         id: release_notes_flag

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -56,28 +56,16 @@ jobs:
           export ARTIFACT_NAME=compactc_${{ inputs.tag }}_${{ inputs.architecture }}
           echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe # v31.10.3
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: |
-            extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
-            extra-substituters = https://cache.iog.io
-            accept-flake-config = true
-
-      - name: Cache Nix
-        if: ${{ !inputs.skipCache }}
-        uses: input-output-hk/actions/attic@8663542d03a41382d97ee344a4e3955280db5f95 # latest
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          endpoint: https://attic.ci.iog.io
-          cache: midnight-public
-          access_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
-
       - name: Checkout compactc repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.branch }}
+
+      - name: Setup Nix with cache
+        uses: ./.github/actions/setup-nix-cache
+        with:
+          skip_cache: ${{ inputs.skipCache }}
+          attic_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0


### PR DESCRIPTION
I'm not 100% sure why the scheduled runs fail but manual triggers don't. It seems to be an access issue (see failed run: https://github.com/LFDT-Minokawa/compact/actions/runs/24398526058/job/71262545248):

```
Error: AccessError: Access error: User does not have permission to complete this action.
```

I'm refactoring it to use the safer reusable action I added last week and release-build.yml is the only workflow that slipped through that refactoring, that is, it was still using the old Nix cache step. 

Fixes a couple of typos in internal-release.yml.
Ensures the release notes file is empty for scheduled runs of internal-release.