### PR TITLE
[Issue-327] Get output from the fuzzer

### DIFF
--- a/.github/workflows/compiler-fuzzer.yml
+++ b/.github/workflows/compiler-fuzzer.yml
@@ -38,6 +38,13 @@ jobs:
           nix develop .#compiler --command yarn install
           nix develop .#compiler --command yarn test:fuzzer
 
+      - name: Upload failed contracts
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: failed-contracts
+          path: tests-e2e/failed-contracts/
+
       - name: Publish Test Report
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ reports
 *.log
 logs
 dist
+
+# failed fuzzer tests
+tests-e2e/failed-contracts/

--- a/tests-e2e/src/tests/fuzzer.e2e.test.ts
+++ b/tests-e2e/src/tests/fuzzer.e2e.test.ts
@@ -22,6 +22,7 @@ import { generate } from '../fuzzer/fuzzers.cjs';
 const contractsDir: string = createTempFolder();
 generate(contractsDir, process.env.NO_OF_FUZZER_TESTS || 1000);
 const generatedContracts = fs.readdirSync(contractsDir);
+const failDir = path.join(process.cwd(), 'failed-contracts');
 
 describe.skipIf(isRelease())('[E2E] Fuzzer tests for compiler', () => {
     generatedContracts.forEach((fileName) => {
@@ -31,15 +32,21 @@ describe.skipIf(isRelease())('[E2E] Fuzzer tests for compiler', () => {
         test(`should be able to compile synthetic contract: '${fileName}'`, async () => {
             const outputDir = createTempFolder();
 
-            const result: Result = await compile([Arguments.SKIP_ZK, filePath, outputDir]);
-            expectCompilerResult(result, {
-                contract: contractContent,
-                ignoreStdOut: false,
-                ignoreStdErr: false,
-            }).stdErrToNotContain(['Internal']);
+            try {
+                const result: Result = await compile([Arguments.SKIP_ZK, filePath, outputDir]);
+                expectCompilerResult(result, {
+                    contract: contractContent,
+                    ignoreStdOut: false,
+                    ignoreStdErr: false,
+                }).stdErrToNotContain(['Internal']);
 
-            if (result.exitCode == ExitCodes.Success) {
-                expectFiles(outputDir).thatGeneratedJSCodeIsValid();
+                if (result.exitCode == ExitCodes.Success) {
+                    expectFiles(outputDir).thatGeneratedJSCodeIsValid();
+                }
+            } catch (e) {
+                fs.mkdirSync(failDir, { recursive: true });
+                fs.writeFileSync(path.join(failDir, fileName), contractContent);
+                throw e;
             }
         });
     });


### PR DESCRIPTION
Right now when the fuzzer CI fails we have no way of seeing the contracts. This PR adds a failed directory that would be downloadable from the workflow run for the team to see what contract caused the compiler to fail or if the fuzzer generated an invalid contract.

Closes #327.