### PR TITLE
[issue-367]getting the failed contracts

### DIFF
--- a/.github/workflows/notify-failed-scheduled.yml
+++ b/.github/workflows/notify-failed-scheduled.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Download failed contracts
         id: contracts
         if: github.event.workflow_run.name == 'Compiler fuzzer'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           name: failed-contracts

--- a/.github/workflows/notify-failed-scheduled.yml
+++ b/.github/workflows/notify-failed-scheduled.yml
@@ -25,16 +25,57 @@ jobs:
       github.event.workflow_run.event == 'schedule'
     permissions:
       issues: write
+      actions: read
     steps:
+      - name: Download failed contracts
+        id: contracts
+        if: github.event.workflow_run.name == 'Compiler fuzzer'
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: failed-contracts
+          path: failed-contracts
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read failed contracts
+        id: read-contracts
+        if: steps.contracts.outcome == 'success'
+        run: |
+          content=""
+          for f in failed-contracts/*; do
+            name=$(basename "$f")
+            body=$(cat "$f")
+            content="${content}<details><summary>${name}</summary>
+
+          \`\`\`
+          ${body}
+          \`\`\`
+
+          </details>
+
+          "
+          done
+          # Write to file to avoid escaping issues
+          echo "$content" > /tmp/contract-section.md
+
       - name: Create or update issue
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
+            const fs = require('fs');
             const workflowName = context.payload.workflow_run.name;
             const runUrl = context.payload.workflow_run.html_url;
             const runId = context.payload.workflow_run.id;
             const branch = context.payload.workflow_run.head_branch;
             const date = new Date().toISOString().split('T')[0];
+
+            let contractSection = '';
+            try {
+              contractSection = '\n\n### Failed contracts\n\n' + fs.readFileSync('/tmp/contract-section.md', 'utf8');
+            } catch {
+              // No failed contracts artifact available
+            }
 
             const title = `Scheduled CI failure: ${workflowName}`;
             const label = 'ci-failure';
@@ -72,7 +113,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: existing.number,
-                body: `Still failing as of ${date}.\n\n- **Run:** ${runUrl}\n- **Branch:** \`${branch}\``,
+                body: `Still failing as of ${date}.\n\n- **Run:** ${runUrl}\n- **Branch:** \`${branch}\`${contractSection}`,
               });
               core.info(`Commented on existing issue #${existing.number}`);
             } else {
@@ -91,7 +132,7 @@ jobs:
                   '',
                   'This issue was created automatically and will receive comments on subsequent failures.',
                   'Close it once the problem is resolved.',
-                ].join('\n'),
+                ].join('\n') + contractSection,
               });
               core.info('Created new issue');
             }

--- a/tests-e2e/src/tests/fuzzer.e2e.test.ts
+++ b/tests-e2e/src/tests/fuzzer.e2e.test.ts
@@ -25,29 +25,34 @@ const generatedContracts = fs.readdirSync(contractsDir);
 const failDir = path.join(process.cwd(), 'failed-contracts');
 
 describe.skipIf(isRelease())('[E2E] Fuzzer tests for compiler', () => {
+    fs.mkdirSync(failDir, { recursive: true });
+
     generatedContracts.forEach((fileName) => {
         const filePath = path.join(contractsDir, fileName);
-        const contractContent = getFileContent(filePath);
 
         test(`should be able to compile synthetic contract: '${fileName}'`, async () => {
+            const contractContent = getFileContent(filePath);
             const outputDir = createTempFolder();
 
-            try {
-                const result: Result = await compile([Arguments.SKIP_ZK, filePath, outputDir]);
-                expectCompilerResult(result, {
-                    contract: contractContent,
-                    ignoreStdOut: false,
-                    ignoreStdErr: false,
-                }).stdErrToNotContain(['Internal']);
+            console.log(contractContent);
 
-                if (result.exitCode == ExitCodes.Success) {
-                    expectFiles(outputDir).thatGeneratedJSCodeIsValid();
-                }
-            } catch (e) {
-                fs.mkdirSync(failDir, { recursive: true });
-                fs.writeFileSync(path.join(failDir, fileName), contractContent);
-                throw e;
+            // Write the contract preemptively — remove it if the test passes
+            const failPath = path.join(failDir, fileName);
+            fs.writeFileSync(failPath, contractContent);
+
+            const result: Result = await compile([Arguments.SKIP_ZK, filePath, outputDir]);
+            expectCompilerResult(result, {
+                contract: contractContent,
+                ignoreStdOut: false,
+                ignoreStdErr: false,
+            }).stdErrToNotContain(['Internal']);
+
+            if (result.exitCode == ExitCodes.Success) {
+                expectFiles(outputDir).thatGeneratedJSCodeIsValid();
             }
+
+            // Only reached if the test passed — clean up
+            fs.rmSync(failPath);
         });
     });
 });


### PR DESCRIPTION
- writing the failed contracts to failed-contracts subdir preemptively …(so that if we get a timeout we can still see the contract).
- logging the code of a contract during running it.
- including the failed contracts in the issue created.

Closes #367 (in the sense of us having a way to seeing the failed contracts).