### PR TITLE
Disable merge without changelog and compiler-version update

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,63 @@
+name: Changelog Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  check-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Check for changelog and compiler version updates
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          # Maintainer override via label
+          if echo "$LABELS" | grep -q '"skip-changelog"'; then
+            echo "✓ PR labeled skip-changelog"
+            exit 0
+          fi
+
+          BASE_SHA=$(git merge-base "origin/$BASE_REF" HEAD)
+          CHANGED=$(git diff --name-only "$BASE_SHA" HEAD)
+
+          CHANGELOG_UPDATED=false
+          COMPILER_VERSION_BUMPED=false
+          if echo "$CHANGED" | grep -qx 'CHANGELOG.md'; then
+            CHANGELOG_UPDATED=true
+          fi
+          if echo "$CHANGED" | grep -qx 'compiler/compiler-version.ss'; then
+            COMPILER_VERSION_BUMPED=true
+          fi
+
+          if $CHANGELOG_UPDATED && $COMPILER_VERSION_BUMPED; then
+            echo "✓ CHANGELOG.md updated and compiler/compiler-version.ss bumped"
+            exit 0
+          fi
+
+          # Build a targeted error message
+          {
+            echo "This PR is missing required updates:"
+            echo ""
+            $CHANGELOG_UPDATED       || echo "  ✗ CHANGELOG.md was not updated"
+            $COMPILER_VERSION_BUMPED || echo "  ✗ compiler/compiler-version.ss was not bumped"
+            echo ""
+            echo "To fix this, do one of the following:"
+            echo ""
+            echo "  1. Add an entry to CHANGELOG.md describing your change, and bump"
+            echo "     the version in compiler/compiler-version.ss. Commit and push."
+            echo ""
+            echo "  2. If this change genuinely does not need a changelog entry or"
+            echo "     version bump (e.g. a typo fix, internal refactor, or CI-only"
+            echo "     change), ask a maintainer to apply the 'skip-changelog' label"
+            echo "     to this PR. The check will re-run automatically and pass."
+          } >&2
+
+          # Single-line annotation for the PR's Files Changed view
+          echo "::error::Missing CHANGELOG.md entry and/or compiler/compiler-version.ss bump. See job log for details."
+          exit 1


### PR DESCRIPTION
**From a contributor's perspective:**
They open a PR that doesn't touch either the changelog nor the [compact-version.ss](http://compact-version.ss/). The check runs, it fails, the job exits 1, and the merge button is disabled. They have two paths: push a commit that edits changelog and [compact-version.ss](http://compact-version.ss/) (which makes the check to pass), or a maintainer adds the skip-changelog label (which makes the check to pass). Either way the red X becomes a green check and merge unlocks. This limits the ability to skip updating changelog to only folks with write access to our repo.

**Wiring into branch protection:**
The workflow by itself only reports a status. To actually block merging, we need SRE to Settings → Branches → Branch protection rules → add check-changelog.