### PR TITLE
test: Issue #187

### DIFF
--- a/examples/bugs/issue-187/comparisons.compact
+++ b/examples/bugs/issue-187/comparisons.compact
@@ -1,0 +1,41 @@
+// This file is part of Compact.
+// Copyright (C) 2025 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import CompactStandardLibrary;
+
+export ledger count: Counter;
+
+witness get_a(): Uint<8>;
+witness get_b(): Uint<8>;
+
+export circuit less_than(): Boolean {
+  count.increment(1);
+  return disclose(get_a()) < disclose(get_b());
+}
+
+export circuit less_than_or_equal(): Boolean {
+  count.increment(1);
+  return disclose(get_a()) <= disclose(get_b());
+}
+
+export circuit greater_than(): Boolean {
+  count.increment(1);
+  return disclose(get_a()) > disclose(get_b());
+}
+
+export circuit greater_than_or_equal(): Boolean {
+  count.increment(1);
+  return disclose(get_a()) >= disclose(get_b());
+}

--- a/tests-e2e/src/tests/bugs/compiler.bugs.issue187.e2e.test.ts
+++ b/tests-e2e/src/tests/bugs/compiler.bugs.issue187.e2e.test.ts
@@ -39,21 +39,18 @@ type ZkirCircuit = {
     instructions: ZkirInstruction[];
 };
 
-type ExpectedLessThanOperands = {
-    a: 'firstPrivateInput' | 'secondPrivateInput';
-    b: 'firstPrivateInput' | 'secondPrivateInput';
-};
+type PrivateInputPosition = 'firstPrivateInput' | 'secondPrivateInput';
 
 const CONTRACTS_ROOT = buildPathTo('/bugs/issue-187/');
 
-function getExpectedLessThanOperands(circuitName: CircuitName): ExpectedLessThanOperands {
+function getExpectedLessThanOperands(circuitName: CircuitName): [PrivateInputPosition, PrivateInputPosition] {
     switch (circuitName) {
         case 'less_than':
         case 'greater_than_or_equal':
-            return { a: 'firstPrivateInput', b: 'secondPrivateInput' };
+            return ['firstPrivateInput', 'secondPrivateInput'];
         case 'less_than_or_equal':
         case 'greater_than':
-            return { a: 'secondPrivateInput', b: 'firstPrivateInput' };
+            return ['secondPrivateInput', 'firstPrivateInput'];
     }
 }
 
@@ -61,7 +58,7 @@ function getZkir(outputDir: string, circuitName: CircuitName): ZkirCircuit {
     return JSON.parse(getFileContent(`${outputDir}/zkir/${circuitName}.zkir`)) as ZkirCircuit;
 }
 
-function getPrivateInputVars(zkir: ZkirCircuit): number[] {
+function getUint8PrivateInputVars(zkir: ZkirCircuit): number[] {
     return zkir.instructions.flatMap((instruction, index, instructions) => {
         const nextInstruction = instructions[index + 1];
 
@@ -87,22 +84,23 @@ function getLessThanInstruction(zkir: ZkirCircuit): ZkirInstruction {
 
 function expectComparisonToUsePrivateInputsInOrder(outputDir: string, circuitName: CircuitName): void {
     const zkir = getZkir(outputDir, circuitName);
-    const privateInputVars = getPrivateInputVars(zkir);
+    const privateInputVars = getUint8PrivateInputVars(zkir);
     const [firstPrivateInput, secondPrivateInput] = privateInputVars;
     const lessThanInstruction = getLessThanInstruction(zkir);
-    const expectedLessThanOperands = getExpectedLessThanOperands(circuitName);
+    const [expectedA, expectedB] = getExpectedLessThanOperands(circuitName);
     const privateInputs = {
         firstPrivateInput,
         secondPrivateInput,
     };
 
     expect(privateInputVars).toHaveLength(2);
-    expect(lessThanInstruction.a).toBe(privateInputs[expectedLessThanOperands.a]);
-    expect(lessThanInstruction.b).toBe(privateInputs[expectedLessThanOperands.b]);
+    expect(lessThanInstruction.bits).toBe(8);
+    expect(lessThanInstruction.a).toBe(privateInputs[expectedA]);
+    expect(lessThanInstruction.b).toBe(privateInputs[expectedB]);
 }
 
 describe('[Bugs] [Issue #187] comparison operators preserve operand evaluation order in ZKIR', () => {
-    test('provided comparison operators should compile left and right witness inputs in source order', async () => {
+    test('comparison operators should compile left and right witness inputs in source order', async () => {
         const filePath = CONTRACTS_ROOT + 'comparisons.compact';
 
         const outputDir = createTempFolder();

--- a/tests-e2e/src/tests/bugs/compiler.bugs.issue187.e2e.test.ts
+++ b/tests-e2e/src/tests/bugs/compiler.bugs.issue187.e2e.test.ts
@@ -1,0 +1,119 @@
+// This file is part of Compact.
+// Copyright (C) 2025 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Result } from 'execa';
+import { describe, expect, test } from 'vitest';
+import {
+    buildPathTo,
+    compile,
+    compilerDefaultOutput,
+    createTempFolder,
+    expectCompilerResult,
+    expectFiles,
+    getFileContent,
+} from '@';
+
+type CircuitName = 'less_than' | 'less_than_or_equal' | 'greater_than' | 'greater_than_or_equal';
+
+type ZkirInstruction = {
+    op: string;
+    var?: number;
+    a?: number;
+    b?: number;
+    bits?: number;
+};
+
+type ZkirCircuit = {
+    instructions: ZkirInstruction[];
+};
+
+type ExpectedLessThanOperands = {
+    a: 'firstPrivateInput' | 'secondPrivateInput';
+    b: 'firstPrivateInput' | 'secondPrivateInput';
+};
+
+const CONTRACTS_ROOT = buildPathTo('/bugs/issue-187/');
+
+function getExpectedLessThanOperands(circuitName: CircuitName): ExpectedLessThanOperands {
+    switch (circuitName) {
+        case 'less_than':
+        case 'greater_than_or_equal':
+            return { a: 'firstPrivateInput', b: 'secondPrivateInput' };
+        case 'less_than_or_equal':
+        case 'greater_than':
+            return { a: 'secondPrivateInput', b: 'firstPrivateInput' };
+    }
+}
+
+function getZkir(outputDir: string, circuitName: CircuitName): ZkirCircuit {
+    return JSON.parse(getFileContent(`${outputDir}/zkir/${circuitName}.zkir`)) as ZkirCircuit;
+}
+
+function getPrivateInputVars(zkir: ZkirCircuit): number[] {
+    return zkir.instructions.flatMap((instruction, index, instructions) => {
+        const nextInstruction = instructions[index + 1];
+
+        if (
+            instruction.op === 'private_input' &&
+            nextInstruction?.op === 'constrain_bits' &&
+            nextInstruction.var !== undefined &&
+            nextInstruction.bits === 8
+        ) {
+            return [nextInstruction.var];
+        }
+
+        return [];
+    });
+}
+
+function getLessThanInstruction(zkir: ZkirCircuit): ZkirInstruction {
+    const lessThanInstruction = zkir.instructions.find((instruction) => instruction.op === 'less_than');
+
+    expect(lessThanInstruction).toBeDefined();
+    return lessThanInstruction as ZkirInstruction;
+}
+
+function expectComparisonToUsePrivateInputsInOrder(outputDir: string, circuitName: CircuitName): void {
+    const zkir = getZkir(outputDir, circuitName);
+    const privateInputVars = getPrivateInputVars(zkir);
+    const [firstPrivateInput, secondPrivateInput] = privateInputVars;
+    const lessThanInstruction = getLessThanInstruction(zkir);
+    const expectedLessThanOperands = getExpectedLessThanOperands(circuitName);
+    const privateInputs = {
+        firstPrivateInput,
+        secondPrivateInput,
+    };
+
+    expect(privateInputVars).toHaveLength(2);
+    expect(lessThanInstruction.a).toBe(privateInputs[expectedLessThanOperands.a]);
+    expect(lessThanInstruction.b).toBe(privateInputs[expectedLessThanOperands.b]);
+}
+
+describe('[Bugs] [Issue #187] comparison operators preserve operand evaluation order in ZKIR', () => {
+    test('provided comparison operators should compile left and right witness inputs in source order', async () => {
+        const filePath = CONTRACTS_ROOT + 'comparisons.compact';
+
+        const outputDir = createTempFolder();
+        const result: Result = await compile([filePath, outputDir]);
+
+        expectCompilerResult(result).toBeSuccess(/Compiling 4 circuits:/, compilerDefaultOutput());
+        expectFiles(outputDir).thatGeneratedJSCodeIsValid();
+
+        expectComparisonToUsePrivateInputsInOrder(outputDir, 'less_than');
+        expectComparisonToUsePrivateInputsInOrder(outputDir, 'less_than_or_equal');
+        expectComparisonToUsePrivateInputsInOrder(outputDir, 'greater_than');
+        expectComparisonToUsePrivateInputsInOrder(outputDir, 'greater_than_or_equal');
+    });
+});


### PR DESCRIPTION
## Summary

Verifies #187 

- Add a Compact fixture covering `<`, `<=`, `>`, and `>=` comparisons with disclosed `Uint<8>` witnesses.
- Add an E2E regression test that compiles the fixture and inspects generated ZKIR.
- Assert that `<=` and `>` lower to `less_than` with swapped operands, while preserving private input creation order, which I believe matches the fixed compiler behaviour behind the original proof mismatch.

```
󰀵 algalon  …/compact/tests-e2e   lowhung/issue-187-qa ?   v24.11.1   13:53 
 RELEASE=true PATH="$HOME/.compact/versions/0.31.0/aarch64-darwin:$PATH" \
  yarn vitest run --config vitest.config.ts src/tests/bugs/compiler.bugs.issue187.e2e.test.ts

yarn run v1.22.22
$ /Users/algalon/CompactProjects/compact/tests-e2e/node_modules/.bin/vitest run --config vitest.config.ts src/tests/bugs/compiler.bugs.issue187.e2e.test.ts

 RUN  v3.2.4 /Users/algalon/CompactProjects/compact/tests-e2e

Sourcemap for "/Users/algalon/CompactProjects/compact/tests-e2e/node_modules/allure-vitest/dist/setup.js" points to missing source files
[15:32:06.766] INFO (65386): Cleaning folder: ./reports/allure-reports
[15:32:06.768] INFO (65386): Deleting: ./reports/allure-reports
[15:32:06.769] INFO (65386): Running test: [Bugs] [Issue #187] comparison operators preserve operand evaluation order in ZKIR > comparison operators should compile left and right witness inputs in source order
[15:32:06.769] INFO (65386): Creating temp folder: /private/var/folders/j2/q3h_5lnj4rl7zzrgllt7wb680000gn/T/temp-test-3MXVN2/
[15:32:06.769] INFO (65386): Using system compiler: compactc
[15:32:07.354] INFO (65386): ---- Result ----
[15:32:07.354] INFO (65386): command: compactc /Users/algalon/CompactProjects/compact/examples/bugs/issue-187/comparisons.compact /private/var/folders/j2/q3h_5lnj4rl7zzrgllt7wb680000gn/T/temp-test-3MXVN2/
[15:32:07.354] INFO (65386): stdout:
[15:32:07.354] INFO (65386): stderr: Compiling 4 circuits:
[15:32:07.354] INFO (65386): exit code: 0
[15:32:07.354] INFO (65386): ---- End ----
[15:32:07.355] INFO (65386): AssertFiles: /private/var/folders/j2/q3h_5lnj4rl7zzrgllt7wb680000gn/T/temp-test-3MXVN2/
[15:32:07.362] INFO (65386): No errors in generated js file
[15:32:07.363] INFO (65386): Cleaning up temp folders
[15:32:07.364] INFO (65386): Cleaning folder: /private/var/folders/j2/q3h_5lnj4rl7zzrgllt7wb680000gn/T/temp-test-3MXVN2/
[15:32:07.364] INFO (65386): Deleting: /private/var/folders/j2/q3h_5lnj4rl7zzrgllt7wb680000gn/T/temp-test-3MXVN2/
 ✓ src/tests/bugs/compiler.bugs.issue187.e2e.test.ts (1 test) 600ms
   ✓ [Bugs] [Issue #187] comparison operators preserve operand evaluation order in ZKIR (1)
     ✓ comparison operators should compile left and right witness inputs in source order  594ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  15:32:06
   Duration  1.02s (transform 54ms, setup 258ms, collect 5ms, tests 600ms, environment 0ms, prepare 40ms)

 HTML  Report is generated
       You can run npx vite preview --outDir reports/html to see the test results.
✨  Done in 1.67s.
```