### PR TITLE
test: issue for 237

### DIFF
--- a/tests-e2e/src/contract-assertions.ts
+++ b/tests-e2e/src/contract-assertions.ts
@@ -15,7 +15,7 @@
 
 import fs from 'fs';
 import { expect } from 'vitest';
-import { ContractInfo, ContractInfoCircuit, ContractInfoLedger, OrdinaryType } from './types';
+import { ContractInfo, ContractInfoCircuit, ContractInfoLedger, LedgerAdtType, OrdinaryType } from './types';
 
 export class AssertContract {
     private folderPath: string = '';
@@ -263,7 +263,7 @@ export class AssertContract {
         return this;
     }
 
-    thatLedgerMapValueIs(fieldName: string, expectedValue: OrdinaryType): AssertContract {
+    thatLedgerMapValueIs(fieldName: string, expectedValue: OrdinaryType | LedgerAdtType): AssertContract {
         const field = this.getLedgerFieldFromJson(fieldName);
         expect(field, `'${fieldName}' not found in contract-info.json ledger`).toBeDefined();
         expect(field?.storage, `'${fieldName}' is not a Map in contract-info.json`).toBe('Map');

--- a/tests-e2e/src/contract-assertions.ts
+++ b/tests-e2e/src/contract-assertions.ts
@@ -241,7 +241,7 @@ export class AssertContract {
         return this;
     }
 
-    /** Asserts the `type` payload for Cell/Set/List/MerkleTree/HistoricMerkleTree storage. Map has no `type`. */
+    /** Asserts the `type` payload for Cell/Set/List/MerkleTree/HistoricMerkleTree. */
     thatLedgerFieldHasType(fieldName: string, expectedType: OrdinaryType): AssertContract {
         const field = this.getLedgerFieldFromJson(fieldName);
         expect(field, `'${fieldName}' not found in contract-info.json ledger`).toBeDefined();

--- a/tests-e2e/src/contract-assertions.ts
+++ b/tests-e2e/src/contract-assertions.ts
@@ -15,7 +15,7 @@
 
 import fs from 'fs';
 import { expect } from 'vitest';
-import { ContractInfo, ContractInfoCircuit } from './types';
+import { ContractInfo, ContractInfoCircuit, ContractInfoLedger, OrdinaryType } from './types';
 
 export class AssertContract {
     private folderPath: string = '';
@@ -72,6 +72,10 @@ export class AssertContract {
         return this.contractInfo?.circuits.find((c) => c.name === circuitName);
     }
 
+    private getLedgerFieldFromJson(fieldName: string): ContractInfoLedger | undefined {
+        return this.contractInfo?.ledger.find((l) => l.name === fieldName);
+    }
+
     getPureCircuits(): string[] {
         return [...this.pureCircuits];
     }
@@ -90,6 +94,10 @@ export class AssertContract {
 
     getContractInfoCircuits(): ContractInfoCircuit[] | undefined {
         return this.contractInfo?.circuits;
+    }
+
+    getContractInfoLedger(): ContractInfoLedger[] | undefined {
+        return this.contractInfo?.ledger;
     }
 
     thatCompilerVersionIs(expectedVersion: string): AssertContract {
@@ -191,5 +199,90 @@ export class AssertContract {
             .thatCircuitHasNoZkir(circuitName)
             .thatCircuitNoProof(circuitName)
             .thatCircuitIsJsonImpure(circuitName);
+    }
+
+    thatLedgerFieldExists(fieldName: string): AssertContract {
+        const field = this.getLedgerFieldFromJson(fieldName);
+        expect(field, `'${fieldName}' not found in contract-info.json ledger`).toBeDefined();
+        return this;
+    }
+
+    thatLedgerFieldNotInJson(fieldName: string): AssertContract {
+        const field = this.getLedgerFieldFromJson(fieldName);
+        expect(field, `'${fieldName}' should NOT be in contract-info.json ledger`).toBeUndefined();
+        return this;
+    }
+
+    thatLedgerFieldStorageIs(fieldName: string, expectedStorage: ContractInfoLedger['storage']): AssertContract {
+        const field = this.getLedgerFieldFromJson(fieldName);
+        expect(field, `'${fieldName}' not found in contract-info.json ledger`).toBeDefined();
+        expect(field?.storage, `'${fieldName}' storage mismatch in contract-info.json`).toBe(expectedStorage);
+        return this;
+    }
+
+    thatLedgerFieldIsExported(fieldName: string): AssertContract {
+        const field = this.getLedgerFieldFromJson(fieldName);
+        expect(field, `'${fieldName}' not found in contract-info.json ledger`).toBeDefined();
+        expect(field?.exported, `'${fieldName}' should be exported in contract-info.json`).toBe(true);
+        return this;
+    }
+
+    thatLedgerFieldIsNotExported(fieldName: string): AssertContract {
+        const field = this.getLedgerFieldFromJson(fieldName);
+        expect(field, `'${fieldName}' not found in contract-info.json ledger`).toBeDefined();
+        expect(field?.exported, `'${fieldName}' should NOT be exported in contract-info.json`).toBe(false);
+        return this;
+    }
+
+    thatLedgerFieldIndexIs(fieldName: string, expectedIndex: number | number[]): AssertContract {
+        const field = this.getLedgerFieldFromJson(fieldName);
+        expect(field, `'${fieldName}' not found in contract-info.json ledger`).toBeDefined();
+        expect(field?.index, `'${fieldName}' index mismatch in contract-info.json`).toEqual(expectedIndex);
+        return this;
+    }
+
+    /** Asserts the `type` payload for Cell/Set/List/MerkleTree/HistoricMerkleTree storage. Map has no `type`. */
+    thatLedgerFieldHasType(fieldName: string, expectedType: OrdinaryType): AssertContract {
+        const field = this.getLedgerFieldFromJson(fieldName);
+        expect(field, `'${fieldName}' not found in contract-info.json ledger`).toBeDefined();
+        if (field && 'type' in field) {
+            expect(field.type, `'${fieldName}' type mismatch in contract-info.json`).toEqual(expectedType);
+        } else {
+            expect.fail(`'${fieldName}' storage '${field?.storage}' has no 'type' payload in contract-info.json`);
+        }
+        return this;
+    }
+
+    thatLedgerMapKeyIs(fieldName: string, expectedKey: OrdinaryType): AssertContract {
+        const field = this.getLedgerFieldFromJson(fieldName);
+        expect(field, `'${fieldName}' not found in contract-info.json ledger`).toBeDefined();
+        expect(field?.storage, `'${fieldName}' is not a Map in contract-info.json`).toBe('Map');
+        if (field?.storage === 'Map') {
+            expect(field.key, `'${fieldName}' Map key mismatch in contract-info.json`).toEqual(expectedKey);
+        }
+        return this;
+    }
+
+    thatLedgerMapValueIs(fieldName: string, expectedValue: OrdinaryType): AssertContract {
+        const field = this.getLedgerFieldFromJson(fieldName);
+        expect(field, `'${fieldName}' not found in contract-info.json ledger`).toBeDefined();
+        expect(field?.storage, `'${fieldName}' is not a Map in contract-info.json`).toBe('Map');
+        if (field?.storage === 'Map') {
+            expect(field.value, `'${fieldName}' Map value mismatch in contract-info.json`).toEqual(expectedValue);
+        }
+        return this;
+    }
+
+    thatLedgerMerkleTreeDepthIs(fieldName: string, expectedDepth: number): AssertContract {
+        const field = this.getLedgerFieldFromJson(fieldName);
+        expect(field, `'${fieldName}' not found in contract-info.json ledger`).toBeDefined();
+        expect(
+            field?.storage === 'MerkleTree' || field?.storage === 'HistoricMerkleTree',
+            `'${fieldName}' is not a MerkleTree/HistoricMerkleTree in contract-info.json (storage='${field?.storage}')`,
+        ).toBe(true);
+        if (field?.storage === 'MerkleTree' || field?.storage === 'HistoricMerkleTree') {
+            expect(field.depth, `'${fieldName}' MerkleTree depth mismatch in contract-info.json`).toBe(expectedDepth);
+        }
+        return this;
     }
 }

--- a/tests-e2e/src/tests/compiler/compiler.composable.direct.e2e.test.ts
+++ b/tests-e2e/src/tests/compiler/compiler.composable.direct.e2e.test.ts
@@ -132,7 +132,7 @@ describe('[Composable contracts direct] Compiler', () => {
         const mainFilePath = contractsDir + mainFileName;
 
         const contractInfo: ContractInfo = JSON.parse(fs.readFileSync(dependencyFileJsonPath, 'utf8')) as ContractInfo;
-        delete (contractInfo as { witnesses?: [] }).witnesses;
+        delete (contractInfo as Partial<ContractInfo>).witnesses;
 
         fs.writeFileSync(dependencyFileJsonPath, JSON.stringify(contractInfo, null, 2));
         const returnValue = await compileWithContractPath(mainFilePath, 'Main', contractsDir);
@@ -160,7 +160,7 @@ describe('[Composable contracts direct] Compiler', () => {
         const mainFilePath = contractsDir + mainFileName;
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const contractInfo: ContractInfo = JSON.parse(fs.readFileSync(dependencyFileJsonPath, 'utf8'));
-        contractInfo.circuits[0]['result-type']['type-name'] = 'MALFORMED';
+        (contractInfo.circuits[0]['result-type'] as { 'type-name': string })['type-name'] = 'MALFORMED';
         fs.writeFileSync(dependencyFileJsonPath, JSON.stringify(contractInfo, null, 2));
         logger.info(fs.readFileSync(dependencyFileJsonPath, 'utf8'));
         const returnValue = await compileWithContractPath(mainFilePath, 'Main', contractsDir);
@@ -176,7 +176,7 @@ describe('[Composable contracts direct] Compiler', () => {
         const mainFilePath = contractsDir + mainFileName;
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const contractInfo: ContractInfo = JSON.parse(fs.readFileSync(dependencyFileJsonPath, 'utf8'));
-        contractInfo.circuits[0].arguments[0].type['type-name'] = 'MALFORMED';
+        (contractInfo.circuits[0].arguments[0].type as { 'type-name': string })['type-name'] = 'MALFORMED';
         fs.writeFileSync(dependencyFileJsonPath, JSON.stringify(contractInfo, null, 2));
         logger.info(fs.readFileSync(dependencyFileJsonPath, 'utf8'));
         const returnValue = await compileWithContractPath(mainFilePath, 'Main', contractsDir);

--- a/tests-e2e/src/tests/compiler/compiler.ledger.e2e.test.ts
+++ b/tests-e2e/src/tests/compiler/compiler.ledger.e2e.test.ts
@@ -1,0 +1,121 @@
+// This file is part of Compact.
+// Copyright (C) 2025 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Result } from 'execa';
+import { describe, test } from 'vitest';
+import {
+    Arguments,
+    AssertContract,
+    buildPathTo,
+    compile,
+    compilerDefaultOutput,
+    createTempFolder,
+    expectCompilerResult,
+} from '@';
+
+describe('[Contract Info] Ledger added to contract-info.json', async () => {
+    const CONTRACT_FILE_PATH = buildPathTo('election.compact');
+    const outputDir = createTempFolder();
+    const result: Result = await compile([Arguments.SKIP_ZK, CONTRACT_FILE_PATH, outputDir]);
+    expectCompilerResult(result).toBeSuccess('', compilerDefaultOutput());
+    const contractAssertion = new AssertContract().expect(outputDir);
+
+    test('ledger for primitive types added correctly', () => {
+        // ledger authority: Bytes<32>;
+        contractAssertion
+            .thatLedgerFieldExists('authority')
+            .thatLedgerFieldIndexIs('authority', 0)
+            .thatLedgerFieldStorageIs('authority', 'Cell')
+            .thatLedgerFieldHasType('authority', { 'type-name': 'Bytes', length: 32 })
+            .thatLedgerFieldIsNotExported('authority');
+    });
+
+    test('ledger for program defined types added correctly', () => {
+        // enum PublicState { setup, commit, reveal, final, }
+        // ledger state: PublicState;
+        contractAssertion
+            .thatLedgerFieldExists('state')
+            .thatLedgerFieldIndexIs('state', 1)
+            .thatLedgerFieldStorageIs('state', 'Cell')
+            .thatLedgerFieldHasType('state', {
+                'type-name': 'Enum',
+                name: 'PublicState',
+                elements: ['setup', 'commit', 'reveal', 'final'],
+            })
+            .thatLedgerFieldIsNotExported('state');
+
+        // ledger topic: Maybe<Opaque<"string">>;
+        contractAssertion
+            .thatLedgerFieldExists('topic')
+            .thatLedgerFieldIndexIs('topic', 2)
+            .thatLedgerFieldStorageIs('topic', 'Cell')
+            .thatLedgerFieldHasType('topic', {
+                'type-name': 'Struct',
+                name: 'Maybe',
+                elements: [
+                    {
+                        name: 'is_some',
+                        type: {
+                            'type-name': 'Boolean',
+                        },
+                    },
+                    {
+                        name: 'value',
+                        type: {
+                            'type-name': 'Opaque',
+                            tsType: 'string',
+                        },
+                    },
+                ],
+            })
+            .thatLedgerFieldIsNotExported('topic');
+    });
+
+    test('ledger for ADT added correctly', () => {
+        // ledger tally_yes: Counter;
+        contractAssertion
+            .thatLedgerFieldExists('tally_yes')
+            .thatLedgerFieldIndexIs('tally_yes', 3)
+            .thatLedgerFieldStorageIs('tally_yes', 'Counter');
+
+        // ledger committed_votes: MerkleTree<10, Bytes<32>>;
+        contractAssertion
+            .thatLedgerFieldExists('committed_votes')
+            .thatLedgerFieldIndexIs('committed_votes', 5)
+            .thatLedgerFieldStorageIs('committed_votes', 'MerkleTree')
+            .thatLedgerMerkleTreeDepthIs('committed_votes', 10)
+            .thatLedgerFieldHasType('committed_votes', {
+                'type-name': 'Bytes',
+                length: 32,
+            });
+
+        // ledger revealed: Set<Bytes<32>>;
+        contractAssertion
+            .thatLedgerFieldExists('revealed')
+            .thatLedgerFieldIndexIs('revealed', 8)
+            .thatLedgerFieldStorageIs('revealed', 'Set')
+            .thatLedgerFieldHasType('revealed', {
+                'type-name': 'Bytes',
+                length: 32,
+            });
+    });
+
+    test("ledger fields not in contract-info.json don't exist", () => {
+        contractAssertion
+            .thatLedgerFieldNotInJson('non_existent_field_1')
+            .thatLedgerFieldNotInJson('non_existent_field_2')
+            .thatLedgerFieldNotInJson('non_existent_field_3');
+    });
+});

--- a/tests-e2e/src/tests/compiler/compiler.version.e2e.test.ts
+++ b/tests-e2e/src/tests/compiler/compiler.version.e2e.test.ts
@@ -41,6 +41,13 @@ describe('[PM-21414] Compiler and language versions added to contract-info.json'
         const compilerVersion = await getCompilerVersion();
         const languageVersion = await getLanguageVersion();
 
-        new AssertContract().expect(outputDir).thatCompilerVersionIs(compilerVersion).thatLanguageVersionIs(languageVersion);
+        console.log(outputDir);
+        new AssertContract()
+            .expect(outputDir)
+            .thatCompilerVersionIs(compilerVersion)
+            .thatLanguageVersionIs(languageVersion)
+            .thatLedgerFieldExists('round')
+            .thatLedgerFieldIsExported('round')
+            .thatLedgerFieldStorageIs('round', 'Counter');
     });
 });

--- a/tests-e2e/src/tests/compiler/compiler.version.e2e.test.ts
+++ b/tests-e2e/src/tests/compiler/compiler.version.e2e.test.ts
@@ -41,9 +41,6 @@ describe('[PM-21414] Compiler and language versions added to contract-info.json'
         const compilerVersion = await getCompilerVersion();
         const languageVersion = await getLanguageVersion();
 
-        new AssertContract()
-            .expect(outputDir)
-            .thatCompilerVersionIs(compilerVersion)
-            .thatLanguageVersionIs(languageVersion);
+        new AssertContract().expect(outputDir).thatCompilerVersionIs(compilerVersion).thatLanguageVersionIs(languageVersion);
     });
 });

--- a/tests-e2e/src/tests/compiler/compiler.version.e2e.test.ts
+++ b/tests-e2e/src/tests/compiler/compiler.version.e2e.test.ts
@@ -41,7 +41,6 @@ describe('[PM-21414] Compiler and language versions added to contract-info.json'
         const compilerVersion = await getCompilerVersion();
         const languageVersion = await getLanguageVersion();
 
-        console.log(outputDir);
         new AssertContract()
             .expect(outputDir)
             .thatCompilerVersionIs(compilerVersion)

--- a/tests-e2e/src/tests/compiler/compiler.version.e2e.test.ts
+++ b/tests-e2e/src/tests/compiler/compiler.version.e2e.test.ts
@@ -44,9 +44,6 @@ describe('[PM-21414] Compiler and language versions added to contract-info.json'
         new AssertContract()
             .expect(outputDir)
             .thatCompilerVersionIs(compilerVersion)
-            .thatLanguageVersionIs(languageVersion)
-            .thatLedgerFieldExists('round')
-            .thatLedgerFieldIsExported('round')
-            .thatLedgerFieldStorageIs('round', 'Counter');
+            .thatLanguageVersionIs(languageVersion);
     });
 });

--- a/tests-e2e/src/types.ts
+++ b/tests-e2e/src/types.ts
@@ -13,13 +13,57 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-interface Type {
-    'type-name': string;
+type PrimitiveType = BooleanType | FieldType | UintType | BytesType | OpaqueType | VectorType | TupleType;
+
+interface BooleanType {
+    'type-name': 'Boolean';
 }
+
+interface FieldType {
+    'type-name': 'Field';
+}
+
+interface UintType {
+    'type-name': 'Uint';
+    maxval: number;
+}
+
+interface BytesType {
+    'type-name': 'Bytes';
+    length: number;
+}
+
+interface OpaqueType {
+    'type-name': 'Opaque';
+    tsType: 'string' | 'Uint8Array';
+}
+
+interface VectorType {
+    'type-name': 'Vector';
+    length: number;
+    type: PrimitiveType;
+}
+
+interface TupleType {
+    'type-name': 'Tuple';
+    types: PrimitiveType[];
+}
+
+/** Program defined type */
+interface StructType {
+    'type-name': 'Struct';
+    name: string;
+    elements: {
+        name: string;
+        type: PrimitiveType;
+    }[];
+}
+
+export type OrdinaryType = PrimitiveType | StructType;
 
 interface Argument {
     name: string;
-    type: Type;
+    type: OrdinaryType;
 }
 
 /** Circuit entry from contract-info.json */
@@ -28,7 +72,61 @@ export interface ContractInfoCircuit {
     pure: boolean;
     proof: boolean;
     arguments: Argument[];
-    'result-type': Type;
+    'result-type': OrdinaryType;
+}
+
+/** Ledger entry from contract-info.json — discriminated by `storage`. */
+export type ContractInfoLedger =
+    | LedgerCell
+    | LedgerCounter
+    | LedgerSet
+    | LedgerList
+    | LedgerMap
+    | LedgerMerkleTree
+    | LedgerHistoricMerkleTree;
+
+interface LedgerEntryBase {
+    name: string;
+    index: number | number[];
+    exported: boolean;
+}
+
+interface LedgerCell extends LedgerEntryBase {
+    storage: 'Cell';
+    type: OrdinaryType;
+}
+
+interface LedgerCounter extends LedgerEntryBase {
+    storage: 'Counter';
+}
+
+interface LedgerSet extends LedgerEntryBase {
+    storage: 'Set';
+    type: OrdinaryType;
+}
+
+interface LedgerList extends LedgerEntryBase {
+    storage: 'List';
+    type: OrdinaryType;
+}
+
+interface LedgerMap extends LedgerEntryBase {
+    storage: 'Map';
+    key: OrdinaryType;
+    // Ledger Map value can be either ADT or Ordinary Type
+    value: OrdinaryType;
+}
+
+interface LedgerMerkleTree extends LedgerEntryBase {
+    storage: 'MerkleTree';
+    depth: number;
+    type: OrdinaryType;
+}
+
+interface LedgerHistoricMerkleTree extends LedgerEntryBase {
+    storage: 'HistoricMerkleTree';
+    depth: number;
+    type: OrdinaryType;
 }
 
 /** Structure of contract-info.json */
@@ -39,4 +137,5 @@ export interface ContractInfo {
     circuits: ContractInfoCircuit[];
     witnesses: unknown[];
     contracts: unknown[];
+    ledger: ContractInfoLedger[];
 }

--- a/tests-e2e/src/types.ts
+++ b/tests-e2e/src/types.ts
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-type PrimitiveType = BooleanType | FieldType | UintType | BytesType | OpaqueType | VectorType | TupleType;
+type PrimitiveType = BooleanType | FieldType | UintType | BytesType | OpaqueType | VectorType | TupleType | EnumType;
 
 interface BooleanType {
     'type-name': 'Boolean';
@@ -50,6 +50,15 @@ interface TupleType {
 }
 
 /** Program defined type */
+
+export type ProgramDefinedType = EnumType | StructType;
+
+interface EnumType {
+    'type-name': 'Enum';
+    name: string;
+    elements: string[];
+}
+
 interface StructType {
     'type-name': 'Struct';
     name: string;
@@ -59,7 +68,7 @@ interface StructType {
     }[];
 }
 
-export type OrdinaryType = PrimitiveType | StructType;
+export type OrdinaryType = PrimitiveType | ProgramDefinedType;
 
 interface Argument {
     name: string;

--- a/tests-e2e/src/types.ts
+++ b/tests-e2e/src/types.ts
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-type PrimitiveType = BooleanType | FieldType | UintType | BytesType | OpaqueType | VectorType | TupleType | EnumType;
+type PrimitiveType = BooleanType | FieldType | UintType | BytesType | OpaqueType | VectorType | TupleType;
 
 interface BooleanType {
     'type-name': 'Boolean';
@@ -41,12 +41,12 @@ interface OpaqueType {
 interface VectorType {
     'type-name': 'Vector';
     length: number;
-    type: PrimitiveType;
+    type: OrdinaryType;
 }
 
 interface TupleType {
     'type-name': 'Tuple';
-    types: PrimitiveType[];
+    types: OrdinaryType[];
 }
 
 /** Program defined type */
@@ -64,7 +64,7 @@ interface StructType {
     name: string;
     elements: {
         name: string;
-        type: PrimitiveType;
+        type: OrdinaryType;
     }[];
 }
 

--- a/tests-e2e/src/types.ts
+++ b/tests-e2e/src/types.ts
@@ -113,8 +113,8 @@ interface LedgerList extends LedgerEntryBase {
 interface LedgerMap extends LedgerEntryBase {
     storage: 'Map';
     key: OrdinaryType;
-    // Ledger Map value can be either ADT or Ordinary Type
-    value: OrdinaryType;
+    /** Map value may be a nested ADT (Cell/Counter/Set/List/Map/MerkleTree/HistoricMerkleTree) or an OrdinaryType. */
+    value: OrdinaryType | LedgerAdtType;
 }
 
 interface LedgerMerkleTree extends LedgerEntryBase {
@@ -128,6 +128,15 @@ interface LedgerHistoricMerkleTree extends LedgerEntryBase {
     depth: number;
     type: OrdinaryType;
 }
+
+export type LedgerAdtType =
+    | { 'type-name': 'Cell'; type: OrdinaryType }
+    | { 'type-name': 'Counter' }
+    | { 'type-name': 'Set'; type: OrdinaryType }
+    | { 'type-name': 'List'; type: OrdinaryType }
+    | { 'type-name': 'Map'; key: OrdinaryType; value: OrdinaryType | LedgerAdtType }
+    | { 'type-name': 'MerkleTree'; depth: number; type: OrdinaryType }
+    | { 'type-name': 'HistoricMerkleTree'; depth: number; type: OrdinaryType };
 
 /** Structure of contract-info.json */
 export interface ContractInfo {

--- a/tests-e2e/src/types.ts
+++ b/tests-e2e/src/types.ts
@@ -50,7 +50,6 @@ interface TupleType {
 }
 
 /** Program defined type */
-
 export type ProgramDefinedType = EnumType | StructType;
 
 interface EnumType {


### PR DESCRIPTION
## Summary

This PR is to verify #237 

* Refactor `Type` interface to be specific for each `PrimitiveType`, `Program-Defined Type` and `ADT`.
* Introduce `ContractInfoLedger` interface for `ledger` field in `contract-info.json`.
* Add more utilities to check generated `ledger` field in `AssertContract` class.
* Added `compiler.ledger.e2e.test.ts` to verify `ledger` field is generated correctly.

## Test
```bash
RELEASE=true PATH="$HOME/.compact/versions/0.31.0/x86_64-unknown-linux-musl:$PATH" \
  yarn vitest run --config vitest.config.ts src/tests/compiler/compiler.ledger.e2e.test.ts

 ✓ src/tests/compiler/compiler.ledger.e2e.test.ts (4 tests) 4ms
   ✓ [Contract Info] Ledger added to contract-info.json (4)
     ✓ ledger for primitive types added correctly 1ms
     ✓ ledger for program defined types added correctly 0ms
     ✓ ledger for ADT added correctly 0ms
     ✓ ledger fields not in contract-info.json don't exist 0ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  12:32:36
   Duration  620ms (transform 59ms, setup 179ms, collect 277ms, tests 4ms, environment 0ms, prepare 48ms)

 HTML  Report is generated
       You can run npx vite preview --outDir reports/html to see the test results.
Done in 1.14s.
```

