### PR TITLE
Add SPDX headers to the usage pages

### DIFF
--- a/doc/compiler-usage.mdx
+++ b/doc/compiler-usage.mdx
@@ -1,3 +1,11 @@
+---
+SPDX-License-Identifier: Apache-2.0
+copyright: This file is part of midnight-docs. Copyright (C) 2025 Midnight Foundation. Licensed under the Apache License, Version 2.0 (the "License"); You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+title: Compiler usage
+sidebar_position: 12
+ORIGINAL Source: doc/compiler-usage.mdx @ https://github.com/LFDT-Minokawa/compact
+---
+
 # Compact compiler usage page
 
 This is the usage page of **compactc**, a compiler for Compact.

--- a/doc/dev-tool-usage.mdx
+++ b/doc/dev-tool-usage.mdx
@@ -1,3 +1,11 @@
+---
+SPDX-License-Identifier: Apache-2.0
+copyright: This file is part of midnight-docs. Copyright (C) 2025 Midnight Foundation. Licensed under the Apache License, Version 2.0 (the "License"); You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+title: Dev-tool usage
+sidebar_position: 11
+ORIGINAL Source: doc/dev-tool-usage.mdx @ https://github.com/LFDT-Minokawa/compact
+---
+
 # Compact command-line tool usage page
 
 This is the usage page of the Compact command-line tool. This tool allows the

--- a/doc/explicit-disclosure.mdx
+++ b/doc/explicit-disclosure.mdx
@@ -3,6 +3,7 @@ SPDX-License-Identifier: Apache-2.0
 copyright: This file is part of midnight-docs. Copyright (C) 2025 Midnight Foundation. Licensed under the Apache License, Version 2.0 (the "License"); You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 title: Explicit disclosure
 sidebar_position: 10
+ORIGINAL Source: doc/explicit-disclosure.mdx @ https://github.com/LFDT-Minokawa/compact
 ---
 
 <div className="lang-ref">

--- a/doc/fixup-usage.mdx
+++ b/doc/fixup-usage.mdx
@@ -1,3 +1,11 @@
+---
+SPDX-License-Identifier: Apache-2.0
+copyright: This file is part of midnight-docs. Copyright (C) 2025 Midnight Foundation. Licensed under the Apache License, Version 2.0 (the "License"); You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+title: Fixup usage
+sidebar_position: 14
+ORIGINAL Source: doc/fixup-usage.mdx @ https://github.com/LFDT-Minokawa/compact
+---
+
 # Compact fixup usage page
 
 This is the usage page of **fixup-compact**, a fix up tool for Compact.

--- a/doc/formatter-usage.mdx
+++ b/doc/formatter-usage.mdx
@@ -1,3 +1,11 @@
+---
+SPDX-License-Identifier: Apache-2.0
+copyright: This file is part of midnight-docs. Copyright (C) 2025 Midnight Foundation. Licensed under the Apache License, Version 2.0 (the "License"); You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+title: Formatter usage
+sidebar_position: 13
+ORIGINAL Source: doc/formatter-usage.mdx @ https://github.com/LFDT-Minokawa/compact
+---
+
 # Compact formatter usage page
 
 This is the usage page of **format-compact**, a formatter for Compact.


### PR DESCRIPTION
also adds a note about the original source location to explicit-disclosure.mdx