### PR TITLE
Add basic support for Secp256k1Point

### DIFF
--- a/compiler/analysis-passes.ss
+++ b/compiler/analysis-passes.ss
@@ -1767,7 +1767,8 @@
           (lambda (type)
             (T type
               [(tfield ,src (field-base (curve-secp256k1))) #t]
-              [(tfield ,src (field-scalar (curve-secp256k1))) #t]))))
+              [(tfield ,src (field-scalar (curve-secp256k1))) #t]
+              [(topaque ,src ,opaque-type) (string=? opaque-type "Secp256k1Point")]))))
       (define (do-call src fold? fun actual-type* build-call)
         (define compatible-args?
           (let ([nactual (length actual-type*)])

--- a/compiler/circuit-passes.ss
+++ b/compiler/circuit-passes.ss
@@ -2317,6 +2317,9 @@
                     (if (feature-zkir-v3)
                         (cons `(anative ,opaque-type) a*)
                         (cons* `(afield) `(afield) a*))]
+                   [("Secp256k1Point")
+                    (assert (feature-zkir-v3))
+                    (cons `(anative ,opaque-type) a*)]
                    [else (cons `(acompress) a*)])]
                 [(tvector ,src ,len ,type)
                  (let ([a^* (f type '())])
@@ -2456,18 +2459,25 @@
                                   (make-list
                                     (quotient (+ len (- (field-bytes) 1)) (field-bytes))
                                     0)))]
-                      [(topaque ,src ,opaque-type) (guard (string=? opaque-type "JubjubPoint"))
+                      [(topaque ,src ,opaque-type)
                        (with-output-language (Lflattened Statement)
-                         (let ([t1 (make-new-id var-name)])
-                           (if (feature-zkir-v3)
-                               (values
-                                 (Wump-single t1)
-                                 (list `(= ,test (,t1) (default ,opaque-type))))
-                               (let ([t2 (make-new-id var-name)])
-                                 (values
-                                   (Wump-vector (list (Wump-single t1) (Wump-single t2)))
-                                   (list `(= ,test (,t1 ,t2) (default ,opaque-type))))))))]
-                      [(topaque ,src ,opaque-type) (trivial (Wump-single 0))]
+                         (case opaque-type
+                           [("JubjubPoint")
+                            (let ([t1 (make-new-id var-name)])
+                              (if (feature-zkir-v3)
+                                  (values
+                                    (Wump-single t1)
+                                    (list `(= ,test (,t1) (default ,opaque-type))))
+                                  (let ([t2 (make-new-id var-name)])
+                                    (values
+                                      (Wump-vector (list (Wump-single t1) (Wump-single t2)))
+                                      (list `(= ,test (,t1 ,t2) (default ,opaque-type)))))))]
+                           [("Secp256k1Point")
+                            (let ([t1 (make-new-id var-name)])
+                              (values
+                                (Wump-single t1)
+                                (list `(= ,test (,t1) (default ,opaque-type)))))]
+                           [else (trivial (Wump-single 0))]))]
                       [(tvector ,src ,len ,type)
                        (let-values ([(wump stmt*) (do-type type)])
                          (values (Wump-vector (make-list len wump)) stmt*))]
@@ -3814,17 +3824,23 @@
            [else (source-errorf src "expected primitive type tcontract for contract call, received ~a"
                                 (format-primitive-type primitive-type))]))]
       [(= ,test (,var-name* ...) (default ,opaque-type))
-       (guard (string=? opaque-type "JubjubPoint"))
        (verify-test program-src test)
        (with-output-language (Lflattened Primitive-Type)
-         (if (feature-zkir-v3)
-             (begin
-               (assert (= (length var-name*) 1))
-               (set-idtype! (car var-name*) (Idtype-Base `(topaque "JubjubPoint"))))
-             (begin
-               (assert (= (length var-name*) 2))
-               (set-idtype! (car var-name*) (Idtype-Base `(tfield (field-native))))
-               (set-idtype! (cadr var-name*) (Idtype-Base `(tfield (field-native)))))))]
+         (case opaque-type
+           [("JubjubPoint")
+            (if (feature-zkir-v3)
+                (begin
+                  (assert (= (length var-name*) 1))
+                  (set-idtype! (car var-name*) (Idtype-Base `(topaque "JubjubPoint"))))
+                (begin
+                  (assert (= (length var-name*) 2))
+                  (set-idtype! (car var-name*) (Idtype-Base `(tfield (field-native))))
+                  (set-idtype! (cadr var-name*) (Idtype-Base `(tfield (field-native))))))]
+           [("Secp256k1Point")
+            (assert (feature-zkir-v3))
+            (assert (= (length var-name*) 1))
+            (set-idtype! (car var-name*) (Idtype-Base `(topaque "Secp256k1Point")))]
+           [else (assert cannot-happen)]))]
       [(= ,test (,var-name1 ,var-name2) (field->bytes ,src ,len ,[* primitive-type]))
        (verify-test src test)
        (unless (T primitive-type

--- a/compiler/field.ss
+++ b/compiler/field.ss
@@ -13,9 +13,13 @@
 ;;; See the License for the specific language governing permissions and
 ;;; limitations under the License.
 
+#!chezscheme
+
 (library (field)
   (export max-field field?
-          max-jubjub-scalar jubjub-scalar?)
+          max-jubjub-scalar jubjub-scalar?
+          max-secp256k1-base secp256k1-base?
+          max-secp256k1-scalar secp256k1-scalar?)
   (import (chezscheme))
 
   (define-syntax define-field-predicate
@@ -36,4 +40,12 @@
   (define (max-jubjub-scalar)
     #xe7db4ea6533afa906673b0101343b00a6682093ccc81082d0970e5ed6f72cb6)
   (define-field-predicate jubjub-scalar? max-jubjub-scalar)
+
+  (define (max-secp256k1-base)
+    (1- (- (expt 2 256) (expt 2 32) 977)))
+  (define-field-predicate secp256k1-base? max-secp256k1-base)
+
+  (define (max-secp256k1-scalar)
+    #xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140)
+  (define-field-predicate secp256k1-scalar? max-secp256k1-scalar)
 )

--- a/compiler/midnight-natives.ss
+++ b/compiler/midnight-natives.ss
@@ -66,13 +66,23 @@
 ;; ==== Curves
 (declare-native-entry circuit jubjubPointX
   "__compactRuntime.jubjubPointX"
-  ([np (TypeRef JubjubPoint) (discloses "the X coordinate of")])
+  ([pt (TypeRef JubjubPoint) (discloses "the X coordinate of")])
   Field)
 
 (declare-native-entry circuit jubjubPointY
   "__compactRuntime.jubjubPointY"
-  ([np (TypeRef JubjubPoint) (discloses "the Y coordinate of")])
+  ([pt (TypeRef JubjubPoint) (discloses "the Y coordinate of")])
   Field)
+
+(declare-native-entry circuit secp256k1PointX
+  "__compactRuntime.secp256k1PointX"
+  ([pt (TypeRef Secp256k1Point) (discloses "the X coordinate of")])
+  Secp256k1Base)
+
+(declare-native-entry circuit secp256k1PointY
+  "__compactRuntime.secp256k1PointY"
+  ([pt (TypeRef Secp256k1Point) (discloses "the Y coordinate of")])
+  Secp256k1Base)
 
 (declare-native-entry circuit ecAdd
   "__compactRuntime.ecAdd"
@@ -80,16 +90,33 @@
    [b (TypeRef JubjubPoint) (discloses "an elliptic curve sum including")])
   (TypeRef JubjubPoint))
 
+(declare-native-entry circuit ecAdd
+  "__compactRuntime.ecAdd"
+  ([a (TypeRef Secp256k1Point) (discloses "an elliptic curve sum including")]
+   [b (TypeRef Secp256k1Point) (discloses "an elliptic curve sum including")])
+  (TypeRef Secp256k1Point))
+
 (declare-native-entry circuit ecMul
   "__compactRuntime.ecMul"
   ([a (TypeRef JubjubPoint) (discloses "an elliptic curve product including")]
    [b JubjubScalar (discloses "an elliptic curve product including")])
   (TypeRef JubjubPoint))
 
+(declare-native-entry circuit ecMul
+  "__compactRuntime.ecMul"
+  ([a (TypeRef Secp256k1Point) (discloses "an elliptic curve product including")]
+   [b Secp256k1Scalar (discloses "an elliptic curve product including")])
+  (TypeRef Secp256k1Point))
+
 (declare-native-entry circuit ecMulGenerator
   "__compactRuntime.ecMulGenerator"
   ([b JubjubScalar (discloses "the product of the embedded group generator with")])
   (TypeRef JubjubPoint))
+
+(declare-native-entry circuit ecMulGenerator
+  "__compactRuntime.ecMulGenerator"
+  ([b Secp256k1Scalar (discloses "the product of the embedded group generator with")])
+  (TypeRef Secp256k1Point))
 
 (declare-native-entry circuit hashToCurve [A]
   "__compactRuntime.hashToCurve"
@@ -98,8 +125,8 @@
 
 (declare-native-entry circuit constructJubjubPoint
   "__compactRuntime.constructJubjubPoint"
-  ([x Field (discloses "a JubjubPoint containing x coordinate")]
-   [y Field (discloses "a JubjubPoint containing y coordinate")])
+  ([x Field (discloses "a JubjubPoint containing X coordinate")]
+   [y Field (discloses "a JubjubPoint containing Y coordinate")])
   (TypeRef JubjubPoint))
 
 (declare-native-entry witness ownPublicKey

--- a/compiler/standard-library.compact
+++ b/compiler/standard-library.compact
@@ -45,6 +45,7 @@ export circuit right<A, B>(value: B): Either<A, B> {
 
 // Elliptic Curves
 export new type JubjubPoint = Opaque<'JubjubPoint'>;
+export new type Secp256k1Point = Opaque<'Secp256k1Point'>;
 
 // Merkle trees
 export struct MerkleTreeDigest { field: Field; }

--- a/compiler/test.ss
+++ b/compiler/test.ss
@@ -84957,15 +84957,17 @@ groups than for single tests.
         "  var r = contract.circuits.test(context, 0n);"
         "  expect(r.result).toEqual(0n);"
         "  expect(contractCode.ledger(r.context.currentQueryContext.state).scalar).toEqual(0n);"
-        ;; "  r = contract.circuits.test(context, 1000n);"
-        ;; "  expect(r.result).toEqual(1000n);"
-        ;; "  expect(contractCode.ledger(r.context.currentQueryContext.state).scalar).toEqual(1000n);"
-        ;; ,(format "  const MAX_SECP256K1_SCALAR = ~dn;" (max-secp256k1-scalar))
-        ;; "  expect(runtime.MAX_SECP256K1_SCALAR).toEqual(MAX_SECP256K1_SCALAR);"
-        ;; "  r = contract.circuits.test(context, MAX_SECP256K1_SCALAR);"
-        ;; "  expect(r.result).toEqual(MAX_SECP256K1_SCALAR);"
-        ;; "  expect(contractCode.ledger(r.context.currentQueryContext.state).scalar)"
-        ;; "      .toEqual(MAX_SECP256K1_SCALAR);"
+        "  r = contract.circuits.test(context, 1000n);"
+        "  expect(r.result).toEqual(1000n);"
+        "  expect(contractCode.ledger(r.context.currentQueryContext.state).scalar).toEqual(1000n);"
+        ,(format "  const MAX_SECP256K1_SCALAR = ~dn;" (max-secp256k1-scalar))
+        "  expect(runtime.MAX_SECP256K1_SCALAR).toEqual(MAX_SECP256K1_SCALAR);"
+        "  r = contract.circuits.test(context, MAX_SECP256K1_SCALAR);"
+        "  expect(r.result).toEqual(MAX_SECP256K1_SCALAR);"
+        "  expect(contractCode.ledger(r.context.currentQueryContext.state).scalar)"
+        "      .toEqual(MAX_SECP256K1_SCALAR);"
+        "  expect(() => contract.circuits.test(context, MAX_SECP256K1_SCALAR + 1n))"
+        "      .toThrow(runtime.CompactError);"
         "});"
         ))
     )

--- a/compiler/test.ss
+++ b/compiler/test.ss
@@ -84945,12 +84945,108 @@ groups than for single tests.
 (run-tests save-manifest
   (test
     '(
+      "export ledger base: Secp256k1Base;"
+      "export circuit test(s: Secp256k1Base): Secp256k1Base {"
+      "  base = disclose(s);"
+      "  return base;"
+      "}"
+      )
+    (pass-returns reduce-to-zkir
+      (program
+        (circuit (test) ((%s.0 "Base<Secp256k1>"))
+             ("Base<Secp256k1>")
+          (encode (%fld.1 %fld.2 %fld.3 %fld.4) %s.0)
+          (impact 1 16 1 1 1 0 17 1 4 8 8 8 8 %fld.1 %fld.2 %fld.3
+            %fld.4 145)
+          (public_input "Base<Secp256k1>" %t.5)
+          (encode (%fld.6 %fld.7 %fld.8 %fld.9) %t.5)
+          (impact 1 48 80 1 1 0 12 4 8 8 8 8 %fld.6 %fld.7 %fld.8
+            %fld.9)
+          (output %t.5))))
+    (stage-javascript
+      `("test('Secp256k1Base round tripping through the ledger', () => {"
+        "  const [contract, context] = startContract(contractCode, {}, 0);"
+        "  var r = contract.circuits.test(context, 0n);"
+        "  expect(r.result).toEqual(0n);"
+        "  expect(contractCode.ledger(r.context.currentQueryContext.state).base).toEqual(0n);"
+        "  r = contract.circuits.test(context, 1000n);"
+        "  expect(r.result).toEqual(1000n);"
+        "  expect(contractCode.ledger(r.context.currentQueryContext.state).base).toEqual(1000n);"
+        ,(format "  const MAX_SECP256K1_BASE = ~dn;" (max-secp256k1-base))
+        "  expect(runtime.MAX_SECP256K1_BASE).toEqual(MAX_SECP256K1_BASE);"
+        "  r = contract.circuits.test(context, MAX_SECP256K1_BASE);"
+        "  expect(r.result).toEqual(MAX_SECP256K1_BASE);"
+        "  expect(contractCode.ledger(r.context.currentQueryContext.state).base)"
+        "      .toEqual(MAX_SECP256K1_BASE);"
+        "  expect(() => contract.circuits.test(context, MAX_SECP256K1_BASE + 1n))"
+        "      .toThrow(runtime.CompactError);"
+        "});"
+        ))
+    )
+
+  (test
+    '(
+      "export ledger base: Secp256k1Base;"
+      "witness add1(s: Secp256k1Base): Secp256k1Base;"
+      "export circuit test(s: Secp256k1Base): Secp256k1Base {"
+      "  base = disclose(add1(s));"
+      "  return base;"
+      "}"
+      )
+    (pass-returns reduce-to-zkir
+      (program
+        (circuit (test) ((%s.0 "Base<Secp256k1>"))
+             ("Base<Secp256k1>")
+          (private_input "Base<Secp256k1>" %tmp.1)
+          (encode (%fld.2 %fld.3 %fld.4 %fld.5) %tmp.1)
+          (impact 1 16 1 1 1 0 17 1 4 8 8 8 8 %fld.2 %fld.3 %fld.4
+            %fld.5 145)
+          (public_input "Base<Secp256k1>" %t.6)
+          (encode (%fld.7 %fld.8 %fld.9 %fld.10) %t.6)
+          (impact 1 48 80 1 1 0 12 4 8 8 8 8 %fld.7 %fld.8 %fld.9
+            %fld.10)
+          (output %t.6))))
+    (stage-javascript
+      `("test('Secp256k1Base passing through witnesses', () => {"
+        "  const witnesses = {"
+        "    add1(wc: runtime.WitnessContext<{}, number>, s: bigint): [number, bigint] {"
+        "      return [wc.privateState, s + 1n];"
+        "    },"
+        "  };"
+        "  const [contract, context] = startContract(contractCode, witnesses, 0);"
+        "  var r = contract.circuits.test(context, 0n);"
+        "  expect(r.result).toEqual(1n);"
+        "  expect(contractCode.ledger(r.context.currentQueryContext.state).base).toEqual(1n);"
+        "  r = contract.circuits.test(context, 1000n);"
+        "  expect(r.result).toEqual(1001n);"
+        "  expect(contractCode.ledger(r.context.currentQueryContext.state).base).toEqual(1001n);"
+        ,(format "  const MAX_SECP256K1_BASE = ~dn;" (max-secp256k1-base))
+        "  expect(() => contract.circuits.test(context, MAX_SECP256K1_BASE))"
+        "      .toThrow(runtime.CompactError);"
+        "});"
+        ))
+    )
+
+  (test
+    '(
       "export ledger scalar: Secp256k1Scalar;"
       "export circuit test(s: Secp256k1Scalar): Secp256k1Scalar {"
       "  scalar = disclose(s);"
       "  return scalar;"
       "}"
       )
+    (pass-returns reduce-to-zkir
+      (program
+        (circuit (test) ((%s.0 "Scalar<Secp256k1>"))
+             ("Scalar<Secp256k1>")
+          (encode (%fld.1 %fld.2 %fld.3 %fld.4) %s.0)
+          (impact 1 16 1 1 1 0 17 1 4 8 8 8 8 %fld.1 %fld.2 %fld.3
+            %fld.4 145)
+          (public_input "Scalar<Secp256k1>" %t.5)
+          (encode (%fld.6 %fld.7 %fld.8 %fld.9) %t.5)
+          (impact 1 48 80 1 1 0 12 4 8 8 8 8 %fld.6 %fld.7 %fld.8
+            %fld.9)
+          (output %t.5))))
     (stage-javascript
       `("test('Secp256k1Scalar round tripping through the ledger', () => {"
         "  const [contract, context] = startContract(contractCode, {}, 0);"
@@ -84967,6 +85063,49 @@ groups than for single tests.
         "  expect(contractCode.ledger(r.context.currentQueryContext.state).scalar)"
         "      .toEqual(MAX_SECP256K1_SCALAR);"
         "  expect(() => contract.circuits.test(context, MAX_SECP256K1_SCALAR + 1n))"
+        "      .toThrow(runtime.CompactError);"
+        "});"
+        ))
+    )
+
+  (test
+    '(
+      "export ledger scalar: Secp256k1Scalar;"
+      "witness add1(s: Secp256k1Scalar): Secp256k1Scalar;"
+      "export circuit test(s: Secp256k1Scalar): Secp256k1Scalar {"
+      "  scalar = disclose(add1(s));"
+      "  return scalar;"
+      "}"
+      )
+    (pass-returns reduce-to-zkir
+      (program
+        (circuit (test) ((%s.0 "Scalar<Secp256k1>"))
+             ("Scalar<Secp256k1>")
+          (private_input "Scalar<Secp256k1>" %tmp.1)
+          (encode (%fld.2 %fld.3 %fld.4 %fld.5) %tmp.1)
+          (impact 1 16 1 1 1 0 17 1 4 8 8 8 8 %fld.2 %fld.3 %fld.4
+            %fld.5 145)
+          (public_input "Scalar<Secp256k1>" %t.6)
+          (encode (%fld.7 %fld.8 %fld.9 %fld.10) %t.6)
+          (impact 1 48 80 1 1 0 12 4 8 8 8 8 %fld.7 %fld.8 %fld.9
+            %fld.10)
+          (output %t.6))))
+    (stage-javascript
+      `("test('Secp256k1Scalar passing through witnesses', () => {"
+        "  const witnesses = {"
+        "    add1(wc: runtime.WitnessContext<{}, number>, s: bigint): [number, bigint] {"
+        "      return [wc.privateState, s + 1n];"
+        "    },"
+        "  };"
+        "  const [contract, context] = startContract(contractCode, witnesses, 0);"
+        "  var r = contract.circuits.test(context, 0n);"
+        "  expect(r.result).toEqual(1n);"
+        "  expect(contractCode.ledger(r.context.currentQueryContext.state).scalar).toEqual(1n);"
+        "  r = contract.circuits.test(context, 1000n);"
+        "  expect(r.result).toEqual(1001n);"
+        "  expect(contractCode.ledger(r.context.currentQueryContext.state).scalar).toEqual(1001n);"
+        ,(format "  const MAX_SECP256K1_SCALAR = ~dn;" (max-secp256k1-scalar))
+        "  expect(() => contract.circuits.test(context, MAX_SECP256K1_SCALAR))"
         "      .toThrow(runtime.CompactError);"
         "});"
         ))

--- a/compiler/test.ss
+++ b/compiler/test.ss
@@ -18221,7 +18221,7 @@ groups than for single tests.
       )
     (oops
       message: "~a:\n  ~?"
-      irritants: '("testfile.compact line 3 char 10" "no compatible function named ~a is in scope at this call~@[~a~]~@[~a~]~@[~a~]" (ecAdd #f "\n    one function is incompatible with the supplied argument types\n      supplied argument types:\n        (Bytes<32>, JubjubPoint)\n      declared argument types for function at <standard library>:\n        (JubjubPoint, JubjubPoint)" #f)))
+      irritants: '("testfile.compact line 3 char 10" "no compatible function named ~a is in scope at this call~@[~a~]~@[~a~]~@[~a~]" (ecAdd #f "\n    two functions are incompatible with the supplied argument types\n      supplied argument types:\n        (Bytes<32>, JubjubPoint)\n      declared argument types for function at <standard library>:\n        (Secp256k1Point, Secp256k1Point)\n      declared argument types for function at <standard library>:\n        (JubjubPoint, JubjubPoint)" #f)))
     )
 
   (test
@@ -18237,7 +18237,7 @@ groups than for single tests.
       )
     (oops
       message: "~a:\n  ~?"
-      irritants: '("testfile.compact line 7 char 10" "no compatible function named ~a is in scope at this call~@[~a~]~@[~a~]~@[~a~]" (ecAdd #f "\n    one function is incompatible with the supplied argument types\n      supplied argument types:\n        (struct NonJubjubPoint<x: Field, y: Field>, JubjubPoint)\n      declared argument types for function at <standard library>:\n        (JubjubPoint, JubjubPoint)" #f)))
+      irritants: '("testfile.compact line 7 char 10" "no compatible function named ~a is in scope at this call~@[~a~]~@[~a~]~@[~a~]" (ecAdd #f "\n    two functions are incompatible with the supplied argument types\n      supplied argument types:\n        (struct NonJubjubPoint<x: Field, y: Field>, JubjubPoint)\n      declared argument types for function at <standard library>:\n        (Secp256k1Point, Secp256k1Point)\n      declared argument types for function at <standard library>:\n        (JubjubPoint, JubjubPoint)" #f)))
     )
 
   (test
@@ -18255,17 +18255,26 @@ groups than for single tests.
                           [%b.3 (talias #t JubjubPoint
                                   (topaque "JubjubPoint"))])
              (talias #t JubjubPoint (topaque "JubjubPoint")))
-        (native %ecMul.4 ([%a.5 (talias #t JubjubPoint
+        (native %ecAdd.4 ([%a.5 (talias #t Secp256k1Point
+                                  (topaque "Secp256k1Point"))]
+                          [%b.6 (talias #t Secp256k1Point
+                                  (topaque "Secp256k1Point"))])
+             (talias #t Secp256k1Point (topaque "Secp256k1Point")))
+        (native %ecMul.7 ([%a.8 (talias #t JubjubPoint
                                   (topaque "JubjubPoint"))]
-                          [%b.6 (tfield (field-scalar (curve-jubjub)))])
+                          [%b.9 (tfield (field-scalar (curve-jubjub)))])
              (talias #t JubjubPoint (topaque "JubjubPoint")))
-        (circuit %foo.7 ([%c.8 (talias #t JubjubPoint
-                                 (topaque "JubjubPoint"))])
+        (native %ecMul.10 ([%a.11 (talias #t Secp256k1Point
+                                    (topaque "Secp256k1Point"))]
+                           [%b.12 (tfield (field-scalar (curve-secp256k1)))])
+             (talias #t Secp256k1Point (topaque "Secp256k1Point")))
+        (circuit %foo.13 ([%c.14 (talias #t JubjubPoint
+                                   (topaque "JubjubPoint"))])
              (talias #t JubjubPoint (topaque "JubjubPoint"))
           (call %ecAdd.1
-            %c.8
-            (call %ecMul.4
-              %c.8
+            %c.14
+            (call %ecMul.7
+              %c.14
               (cast-to-field (field-scalar (curve-jubjub)) (tunsigned 3)
                 3))))))
     )
@@ -67434,6 +67443,47 @@ groups than for single tests.
         "  ]"
         "}"))
     )
+
+  (test
+    '(
+      "import CompactStandardLibrary;"
+      "ledger wantProof: Boolean;"
+      "export circuit test(r: Secp256k1Scalar, s: Secp256k1Scalar,"
+      "                    z: Secp256k1Scalar,"
+      "                    pk: Secp256k1Point)"
+      "    : Secp256k1Point {"
+      "  wantProof = true;"
+      "  const w = inv(s);"
+      "  const u1 = z * w;"
+      "  const u2 = r * w;"
+      "  return ecAdd(ecMulGenerator(u1), ecMul(pk, u2));"
+      "}"
+      )
+    (output-file "compiler/testdir/zkir/test.zkir"
+      '(
+        "{"
+        "  \"version\": { \"major\": 3, \"minor\": 0 },"
+        "  \"do_communications_commitment\": true,"
+        "  \"inputs\": ["
+        "    { \"name\": \"%r.0\", \"type\": \"Scalar<Secp256k1>\" },"
+        "    { \"name\": \"%s.1\", \"type\": \"Scalar<Secp256k1>\" },"
+        "    { \"name\": \"%z.2\", \"type\": \"Scalar<Secp256k1>\" },"
+        "    { \"name\": \"%pk.3\", \"type\": \"Point<Secp256k1>\" }"
+        "  ],"
+        "  \"outputs\": ["
+        "    \"Point<Secp256k1>\""
+        "  ],"
+        "  \"instructions\": ["
+        "    { \"op\": \"impact\", \"guard\": \"0x01\", \"inputs\": [\"0x10\", \"0x01\", \"0x01\", \"0x01\", \"0x00\", \"0x11\", \"0x01\", \"0x01\", \"0x01\", \"0x01\", \"0x91\"] },"
+        "    { \"op\": \"inv\", \"output\": \"%w.4\", \"a\": \"%s.1\" },"
+        "    { \"op\": \"mul\", \"output\": \"%u1.5\", \"a\": \"%z.2\", \"b\": \"%w.4\" },"
+        "    { \"op\": \"mul\", \"output\": \"%u2.6\", \"a\": \"%r.0\", \"b\": \"%w.4\" },"
+        "    { \"op\": \"ec_mul_generator\", \"output\": \"%t.7\", \"scalar\": \"%u1.5\" },"
+        "    { \"op\": \"ec_mul\", \"output\": \"%t.8\", \"a\": \"%pk.3\", \"scalar\": \"%u2.6\" },"
+        "    { \"op\": \"add\", \"output\": \"%t.9\", \"a\": \"%t.7\", \"b\": \"%t.8\" },"
+        "    { \"op\": \"output\", \"vals\": [\"%t.9\"] }"
+        "  ]"
+        "}")))
 )
 )
 

--- a/compiler/test.ss
+++ b/compiler/test.ss
@@ -84788,14 +84788,15 @@ groups than for single tests.
         "  expect(C.circuits.testFtoJ(Ctxt, 0n).result).toEqual([0n, 0n, 0n]);"
         "  expect(C.circuits.testFtoJ(Ctxt, 1000n).result).toEqual([1000n, 1000n, 1000n]);"
         ,(format "  const MAX_FIELD = ~dn;" (max-field))
-        ,(format "  var EXPECT = ~dn;" (if (feature-zkir-v3)
-                                           (mod (max-field) (1+ (max-jubjub-scalar)))
-                                           (max-field)))
+        ,(format "  const EXPECT = ~dn;" (if (feature-zkir-v3)
+                                             (mod (max-field) (1+ (max-jubjub-scalar)))
+                                             (max-field)))
         "  expect(C.circuits.testFtoJ(Ctxt, MAX_FIELD).result).toEqual([EXPECT, EXPECT, EXPECT]);"
         ""
         "  expect(C.circuits.testJtoF(Ctxt, 0n).result).toEqual([0n, 0n, 0n]);"
         "  expect(C.circuits.testJtoF(Ctxt, 1001n).result).toEqual([1001n, 1001n, 1001n]);"
         ,(format "  const MAX_JUBJUB_SCALAR = ~dn;" (max-jubjub-scalar))
+        "  expect(runtime.MAX_JUBJUB_SCALAR).toEqual(MAX_JUBJUB_SCALAR);"
         "  expect(C.circuits.testJtoF(Ctxt, MAX_JUBJUB_SCALAR).result).toEqual("
         "    [MAX_JUBJUB_SCALAR, MAX_JUBJUB_SCALAR, MAX_JUBJUB_SCALAR]);"
         ""
@@ -84936,5 +84937,38 @@ groups than for single tests.
     )
   )
 
+(run-javascript)
+)
+
+;;; Tests that are only run in ZKIR-v3 mode:
+(parameterize ([feature-zkir-v3 #t])
+(run-tests save-manifest
+  (test
+    '(
+      "export ledger scalar: Secp256k1Scalar;"
+      "export circuit test(s: Secp256k1Scalar): Secp256k1Scalar {"
+      "  scalar = disclose(s);"
+      "  return scalar;"
+      "}"
+      )
+    (stage-javascript
+      `("test('Secp256k1Scalar round tripping through the ledger', () => {"
+        "  const [contract, context] = startContract(contractCode, {}, 0);"
+        "  var r = contract.circuits.test(context, 0n);"
+        "  expect(r.result).toEqual(0n);"
+        "  expect(contractCode.ledger(r.context.currentQueryContext.state).scalar).toEqual(0n);"
+        ;; "  r = contract.circuits.test(context, 1000n);"
+        ;; "  expect(r.result).toEqual(1000n);"
+        ;; "  expect(contractCode.ledger(r.context.currentQueryContext.state).scalar).toEqual(1000n);"
+        ;; ,(format "  const MAX_SECP256K1_SCALAR = ~dn;" (max-secp256k1-scalar))
+        ;; "  expect(runtime.MAX_SECP256K1_SCALAR).toEqual(MAX_SECP256K1_SCALAR);"
+        ;; "  r = contract.circuits.test(context, MAX_SECP256K1_SCALAR);"
+        ;; "  expect(r.result).toEqual(MAX_SECP256K1_SCALAR);"
+        ;; "  expect(contractCode.ledger(r.context.currentQueryContext.state).scalar)"
+        ;; "      .toEqual(MAX_SECP256K1_SCALAR);"
+        "});"
+        ))
+    )
+  )
 (run-javascript)
 )

--- a/compiler/typescript-passes.ss
+++ b/compiler/typescript-passes.ss
@@ -1382,10 +1382,15 @@
                 (let ([type (subst-tcontract type)])
                   (nanopass-case (Ltypescript Type) type
                     [(tboolean ,src) (format "typeof(~a) === 'boolean'" var)]
-                    [(tfield ,src (field-native))
-                     (format "typeof(~a) === 'bigint' && ~:*~a >= 0 && ~:*~a <= __compactRuntime.MAX_FIELD" var)]
-                    [(tfield ,src (field-scalar (curve-jubjub)))
-                     (format "typeof(~a) === 'bigint' && ~:*~a >= 0 && ~:*~a <= __compactRuntime.MAX_JUBJUB_SCALAR" var)]
+                    [(tfield ,src ,ftype)
+                     (let ([field-name
+                             (nanopass-case (Ltypescript Field-Type) ftype
+                               [(field-native) "FIELD"]
+                               [(field-scalar (curve-jubjub)) "JUBJUB_SCALAR"]
+                               [(field-base (curve-secp256k1)) "SECP256K1_BASE"]
+                               [(field-scalar (curve-secp256k1)) "SECP256K1_SCALAR"])])
+                       (format "typeof(~a) === 'bigint' && ~:*~a >= 0 && ~:*~a <= __compactRuntime.MAX_~a"
+                         var field-name))]
                     [(tunsigned ,src ,nat) (format "typeof(~a) === 'bigint' && ~:*~a >= 0n && ~:*~a <= ~dn" var nat)]
                     [(tbytes ,src ,len) (format "~a.buffer instanceof ArrayBuffer && ~:*~a.BYTES_PER_ELEMENT === 1 && ~:*~a.length === ~s" var len)]
                     [(topaque ,src ,opaque-type) "true"]

--- a/compiler/typescript-passes.ss
+++ b/compiler/typescript-passes.ss
@@ -1295,16 +1295,22 @@
                   [(tboolean ,src)
                    "__compactRuntime.CompactTypeBoolean"]
                   [(tfield ,src ,ftype)
-                   "__compactRuntime.CompactTypeField"]
+                   (nanopass-case (Ltypescript Field-Type) ftype
+                     [(field-native) "__compactRuntime.CompactTypeField"]
+                     [(field-scalar (curve-jubjub)) "__compactRuntime.CompactTypeField"]
+                     [(field-base (curve-secp256k1))
+                      "__compactRuntime.CompactTypeSecp256k1Base"]
+                     [(field-scalar (curve-secp256k1))
+                      "__compactRuntime.CompactTypeSecp256k1Scalar"])]
                   [(tunsigned ,src ,nat)
                    (format "new __compactRuntime.CompactTypeUnsignedInteger(~dn, ~d)" nat (byte-length nat))]
                   [(tbytes ,src ,len)
                    (format "new __compactRuntime.CompactTypeBytes(~d)" len)]
                   [(topaque ,src ,opaque-type)
                    (case opaque-type
-                     [("string") (format "__compactRuntime.CompactTypeOpaqueString")]
-                     [("Uint8Array") (format "__compactRuntime.CompactTypeOpaqueUint8Array")]
-                     [("JubjubPoint") (format "__compactRuntime.CompactTypeJubjubPoint")]
+                     [("string") "__compactRuntime.CompactTypeOpaqueString"]
+                     [("Uint8Array") "__compactRuntime.CompactTypeOpaqueUint8Array"]
+                     [("JubjubPoint") "__compactRuntime.CompactTypeJubjubPoint"]
                      ; FIXME: what should happen with other opaque types?
                      [else (source-errorf src "opaque type ~a is not supported" opaque-type)])]
                   [(tvector ,src ,len ,type)

--- a/compiler/zkir-v3-passes.ss
+++ b/compiler/zkir-v3-passes.ss
@@ -660,6 +660,7 @@
           [(topaque ,opaque-type)
            (case opaque-type
              [("JubjubPoint") "Point<Jubjub>"]
+             [("Secp256k1Point") "Point<Secp256k1>"]
              [else "Scalar<BLS12-381>"])]
           [else (assert cannot-happen)])))
 

--- a/compiler/zkir-v3-passes.ss
+++ b/compiler/zkir-v3-passes.ss
@@ -379,6 +379,20 @@
                             (cons `(encode (,fld) ,(car (zkir-val-input* val)))
                               (zkir-instr*)))
                           (cons* fld -2 1 1 code*))]
+                       [(tfield (field-base (curve-secp256k1)))
+                        (let ([fld* (maplr (lambda (ignore) (make-temp-id default-src 'fld))
+                                      (make-list 4))])
+                          (zkir-instr*
+                            (cons `(encode (,fld* ...) ,(car (zkir-val-input* val)))
+                              (zkir-instr*)))
+                          (append (reverse fld*) (list 8 8 8 8 4 1) code*))]
+                       [(tfield (field-scalar (curve-secp256k1)))
+                        (let ([fld* (maplr (lambda (ignore) (make-temp-id default-src 'fld))
+                                      (make-list 4))])
+                          (zkir-instr*
+                            (cons `(encode (,fld* ...) ,(car (zkir-val-input* val)))
+                              (zkir-instr*)))
+                          (append (reverse fld*) (list 8 8 8 8 4 1) code*))]
                        [else (assemble-operand-acc (cons 1 code*) val)]))
                    (assemble-operand-acc (cons 1 code*) val))]
               [(VMstate-value-ADT val type)
@@ -492,6 +506,24 @@
                                   (make-public-input test-val (car var-name*) "Scalar<Jubjub>")
                                   (zkir-instr*)))
                               (values (list -2) (list fld)))]
+                           [(tfield (field-base (curve-secp256k1)))
+                            (let ([fld* (maplr (lambda (ignore) (make-temp-id default-src 'fld))
+                                          (make-list 4))])
+                              (zkir-instr*
+                                (cons*
+                                  `(encode (,fld* ...) ,(car var-name*))
+                                  (make-public-input test-val (car var-name*) "Base<Secp256k1>")
+                                  (zkir-instr*)))
+                              (values (make-list 4 8) fld*))]
+                           [(tfield (field-scalar (curve-secp256k1)))
+                            (let ([fld* (maplr (lambda (ignore) (make-temp-id default-src 'fld))
+                                          (make-list 4))])
+                              (zkir-instr*
+                                (cons*
+                                  `(encode (,fld* ...) ,(car var-name*))
+                                  (make-public-input test-val (car var-name*) "Scalar<Secp256k1>")
+                                  (zkir-instr*)))
+                              (values (make-list 4 8) fld*))]
                            [else
                              (for-each
                                (lambda (var-name)
@@ -993,8 +1025,9 @@
        `((op . "ec_mul") (output . ,outp) (a . ,inp0) (scalar . ,inp1))]
       [(ec_mul_generator ,[* outp] ,[* inp])
        `((op . "ec_mul_generator") (output . ,outp) (scalar . ,inp))]
-      [(encode (,[* outp*] ...) ,[* inp])
-       `((op . "encode") (outputs . ,(list->vector outp*)) (input . ,inp))]
+      [(encode (,outp* ...) ,[* inp])
+       (let ([outp* (maplr Output outp*)])
+         `((op . "encode") (outputs . ,(list->vector outp*)) (input . ,inp)))]
       [(hash_to_curve ,[* outp] ,[* inp*] ...)
        `((op . "hash_to_curve") (output . ,outp) (inputs . ,(list->vector inp*)))]
       [(impact ,[* inp] ,[* inp*] ...)

--- a/examples/camelCase/old/standard.compact
+++ b/examples/camelCase/old/standard.compact
@@ -29,9 +29,9 @@ constructor() {
   const test_20 = degrade_to_transient(default<Bytes<32>>);
   const test_21 = upgrade_from_transient(1 as Field);
   const test_22 = default<JubjubPoint>;
-  const test_23 = ec_add(default<JubjubPoint>, default<JubjubPoint>);
-  const test_24 = ec_mul(default<JubjubPoint>, 5 as JubjubScalar);
-  const test_25 = ec_mul_generator(5 as JubjubScalar);
+  const test_23 = ecAdd(default<JubjubPoint>, default<JubjubPoint>);
+  const test_24 = ecMul(default<JubjubPoint>, 5 as JubjubScalar);
+  const test_25 = ecMulGenerator(5 as JubjubScalar);
   const test_26 = hash_to_curve<Field>(1 as Field);
   const test_27 = default<MerkleTreeDigest>;
   const test_28 = default<MerkleTreePathEntry>;

--- a/flake.lock
+++ b/flake.lock
@@ -944,17 +944,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1778862325,
-        "narHash": "sha256-mYOsQLJ5f8WJfuu13pEQAiQ3N2mPNNjUGQnzIQuJuOA=",
+        "lastModified": 1781004025,
+        "narHash": "sha256-4FIFYlZ2xmY6SAIZHb1loYWh+teavoRBQgCQRhGo5qU=",
         "owner": "midnightntwrk",
         "repo": "midnight-ledger",
-        "rev": "3a7ae0361d03e6eed4fc91e31f6600f334f605d5",
+        "rev": "a7701690027672876057059f61e5412518a31b8f",
         "type": "github"
       },
       "original": {
         "owner": "midnightntwrk",
+        "ref": "ambrona@secp",
         "repo": "midnight-ledger",
-        "rev": "3a7ae0361d03e6eed4fc91e31f6600f334f605d5",
         "type": "github"
       }
     },
@@ -969,17 +969,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1778862325,
-        "narHash": "sha256-mYOsQLJ5f8WJfuu13pEQAiQ3N2mPNNjUGQnzIQuJuOA=",
+        "lastModified": 1781004025,
+        "narHash": "sha256-4FIFYlZ2xmY6SAIZHb1loYWh+teavoRBQgCQRhGo5qU=",
         "owner": "midnightntwrk",
         "repo": "midnight-ledger",
-        "rev": "3a7ae0361d03e6eed4fc91e31f6600f334f605d5",
+        "rev": "a7701690027672876057059f61e5412518a31b8f",
         "type": "github"
       },
       "original": {
         "owner": "midnightntwrk",
+        "ref": "ambrona@secp",
         "repo": "midnight-ledger",
-        "rev": "3a7ae0361d03e6eed4fc91e31f6600f334f605d5",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -63,11 +63,11 @@
         "rust-analyzer-src": "rust-analyzer-src_3"
       },
       "locked": {
-        "lastModified": 1763621140,
-        "narHash": "sha256-nx0zy/+yR57FwloXmatf3CaXgzA4zJqIFbplnpaKn/Y=",
+        "lastModified": 1776931971,
+        "narHash": "sha256-3ZcWjBpZKsiWT0X9CSa6zG+Zk4ZRAmh56KYrm2iRqKU=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "d4e14d370b4763c67ea02a39f01f5366297d61cb",
+        "rev": "5b3016c5f8cdd37d5e557646d369ce76e30666de",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
         "rust-analyzer-src": "rust-analyzer-src_4"
       },
       "locked": {
-        "lastModified": 1763621140,
-        "narHash": "sha256-nx0zy/+yR57FwloXmatf3CaXgzA4zJqIFbplnpaKn/Y=",
+        "lastModified": 1776931971,
+        "narHash": "sha256-3ZcWjBpZKsiWT0X9CSa6zG+Zk4ZRAmh56KYrm2iRqKU=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "d4e14d370b4763c67ea02a39f01f5366297d61cb",
+        "rev": "5b3016c5f8cdd37d5e557646d369ce76e30666de",
         "type": "github"
       },
       "original": {
@@ -227,11 +227,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1767430085,
-        "narHash": "sha256-SiXJ6xv4pS2MDUqfj0/mmG746cGeJrMQGmoFgHLS25Y=",
+        "lastModified": 1775487831,
+        "narHash": "sha256-2lguQpLPQaxpQCJjXhmEEAfabwsAhkP29Z7fgLzHARA=",
         "owner": "nlewo",
         "repo": "nix2container",
-        "rev": "66f4b8a47e92aa744ec43acbb5e9185078983909",
+        "rev": "76be9608a7f4d6c985d28b0e7be903ae2547df3e",
         "type": "github"
       },
       "original": {
@@ -257,11 +257,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1763421233,
-        "narHash": "sha256-Stk9ZYRkGrnnpyJ4eqt9eQtdFWRRIvMxpNRf4sIegnw=",
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "89c2b2330e733d6cdb5eae7b899326930c2c0648",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
         "type": "github"
       },
       "original": {
@@ -273,11 +273,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1763464769,
-        "narHash": "sha256-AJHrsT7VoeQzErpBRlLJM1SODcaayp0joAoEA35yiwM=",
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6f374686605df381de8541c072038472a5ea2e2d",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
         "type": "github"
       },
       "original": {
@@ -416,11 +416,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1763421233,
-        "narHash": "sha256-Stk9ZYRkGrnnpyJ4eqt9eQtdFWRRIvMxpNRf4sIegnw=",
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "89c2b2330e733d6cdb5eae7b899326930c2c0648",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
         "type": "github"
       },
       "original": {
@@ -432,11 +432,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1763464769,
-        "narHash": "sha256-AJHrsT7VoeQzErpBRlLJM1SODcaayp0joAoEA35yiwM=",
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6f374686605df381de8541c072038472a5ea2e2d",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
         "type": "github"
       },
       "original": {
@@ -473,11 +473,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777651898,
-        "narHash": "sha256-EK/0T+w/s1dYUBNlax0MtR7ddA+s2vvfC35aEG2bHnc=",
+        "lastModified": 1780661123,
+        "narHash": "sha256-/s4uzE0Zbdc2xzn0eAH6168Us6Zks94Bt39dVMCN1j4=",
         "owner": "midnightntwrk",
         "repo": "midnight-ledger",
-        "rev": "909292455347b9bdbe6476cddd1fc9b09e78fd70",
+        "rev": "02716c2c95d50654aeb3cb63bfd8386046e4ca7d",
         "type": "github"
       },
       "original": {
@@ -539,11 +539,11 @@
     "rust-analyzer-src_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1763555010,
-        "narHash": "sha256-SG8PRrLir8RkXdyBm/NnuUo3WqS7HW6ltJLZnAWjBjA=",
+        "lastModified": 1776800521,
+        "narHash": "sha256-f8YJfwAOsLFpIoqZuX3yF69UvMLrkx7iVzMH1pJU7cM=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "636c3aa24ec6762347c334c030b5034c351d6e05",
+        "rev": "8954b66d43225e62c92e8bbcc8500191b5cceb1e",
         "type": "github"
       },
       "original": {
@@ -556,11 +556,11 @@
     "rust-analyzer-src_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1763555010,
-        "narHash": "sha256-SG8PRrLir8RkXdyBm/NnuUo3WqS7HW6ltJLZnAWjBjA=",
+        "lastModified": 1776800521,
+        "narHash": "sha256-f8YJfwAOsLFpIoqZuX3yF69UvMLrkx7iVzMH1pJU7cM=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "636c3aa24ec6762347c334c030b5034c351d6e05",
+        "rev": "8954b66d43225e62c92e8bbcc8500191b5cceb1e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -47,12 +47,12 @@
     };
     zkir-v3 = {
       # zkir-v3 binary for v3 IR format
-      url = "github:midnightntwrk/midnight-ledger/3a7ae0361d03e6eed4fc91e31f6600f334f605d5"; # zkir-v3
+      url = "github:midnightntwrk/midnight-ledger/ambrona@secp"; # zkir-v3
       inputs.zkir.follows = "zkir";
     };
     zkir-v3-wasm = {
       # zkir-v3-wasm for test-center v3 support
-      url = "github:midnightntwrk/midnight-ledger/3a7ae0361d03e6eed4fc91e31f6600f334f605d5";
+      url = "github:midnightntwrk/midnight-ledger/ambrona@secp";
       inputs.zkir.follows = "zkir";
     };
     n2c.url = "github:nlewo/nix2container";

--- a/flake.nix
+++ b/flake.nix
@@ -212,7 +212,7 @@
             NODE_PATH = "";
             buildInputs = [
               pkgs.nodejs
-              pkgs.nodePackages.typescript
+              pkgs.typescript
               chez
             ];
             checkPhase = "";

--- a/runtime/src/compact-types.ts
+++ b/runtime/src/compact-types.ts
@@ -275,7 +275,7 @@ export const CompactTypeSecp256k1Base: CompactType<bigint> = {
   },
 
   toValue(value: bigint): ocrt.Value {
-    if (value > MAX_SECP256K1_BASE) {
+    if (value < 0n || value > MAX_SECP256K1_BASE) {
       throw new CompactError('expected Secp256k1Base');
     }
     let res: ocrt.Value = [];
@@ -320,7 +320,7 @@ export const CompactTypeSecp256k1Scalar: CompactType<bigint> = {
   },
 
   toValue(value: bigint): ocrt.Value {
-    if (value > MAX_SECP256K1_SCALAR) {
+    if (value < 0n || value > MAX_SECP256K1_SCALAR) {
       throw new CompactError('expected Secp256k1Scalar');
     }
     let res: ocrt.Value = [];

--- a/runtime/src/compact-types.ts
+++ b/runtime/src/compact-types.ts
@@ -15,6 +15,7 @@
 
 import * as ocrt from '@midnight-ntwrk/onchain-runtime-v3';
 import { CompactError } from './error.js';
+import { MAX_SECP256K1_BASE, MAX_SECP256K1_SCALAR } from './constants.js';
 
 /**
  * A runtime representation of a type in Compact
@@ -239,6 +240,90 @@ export const CompactTypeField: CompactType<bigint> = {
   },
   toValue(value: bigint): ocrt.Value {
     return ocrt.bigIntToValue(value);
+  },
+};
+
+export const CompactTypeSecp256k1Base: CompactType<bigint> = {
+  // Four 64-bit limbs in little-endian order.
+  alignment(): ocrt.Alignment {
+    return [
+      { tag: 'atom', value: { tag: 'bytes', length: 8 } },
+      { tag: 'atom', value: { tag: 'bytes', length: 8 } },
+      { tag: 'atom', value: { tag: 'bytes', length: 8 } },
+      { tag: 'atom', value: { tag: 'bytes', length: 8 } },
+    ];
+  },
+
+  fromValue(value: ocrt.Value): bigint {
+    if (value.length != 4 || value[3] == undefined) {
+      throw new CompactError('expected Secp256k1Base');
+    }
+    let res = ocrt.valueToBigInt([value[3]]);
+    for (let i = 2; i >= 0; --i) {
+      if (value[i] == undefined) {
+        throw new CompactError('expected Secp256k1Base');
+      }
+      res = (res << 64n) | ocrt.valueToBigInt([value[i]]);
+    }
+    if (res > MAX_SECP256K1_BASE) {
+      throw new CompactError('expected Secp256k1Base');
+    }
+    return res;
+  },
+
+  toValue(value: bigint): ocrt.Value {
+    if (value > MAX_SECP256K1_BASE) {
+      throw new CompactError('expected Secp256k1Base');
+    }
+    let res: ocrt.Value = [];
+    const mask = (1n << 64n) - 1n;
+    for (let i = 0; i < 4; ++i) {
+      res = res.concat(ocrt.bigIntToValue(value & mask));
+      value = value >> 64n;
+    }
+    return res;
+  },
+};
+
+export const CompactTypeSecp256k1Scalar: CompactType<bigint> = {
+  // Four 64-bit limbs in little-endian order.
+  alignment(): ocrt.Alignment {
+    return [
+      { tag: 'atom', value: { tag: 'bytes', length: 8 } },
+      { tag: 'atom', value: { tag: 'bytes', length: 8 } },
+      { tag: 'atom', value: { tag: 'bytes', length: 8 } },
+      { tag: 'atom', value: { tag: 'bytes', length: 8 } },
+    ];
+  },
+
+  fromValue(value: ocrt.Value): bigint {
+    if (value.length != 4 || value[3] == undefined) {
+      throw new CompactError('expected Secp256k1Scalar');
+    }
+    let res = ocrt.valueToBigInt([value[3]]);
+    for (let i = 2; i >= 0; --i) {
+      if (value[i] == undefined) {
+        throw new CompactError('expected Secp256k1Scalar');
+      }
+      res = (res << 64n) | ocrt.valueToBigInt([value[i]]);
+    }
+    if (res > MAX_SECP256K1_SCALAR) {
+      throw new CompactError('expected Secp256k1Scalar');
+    }
+    return res;
+  },
+
+  toValue(value: bigint): ocrt.Value {
+    if (value > MAX_SECP256K1_SCALAR) {
+      throw new CompactError('expected Secp256k1Scalar');
+    }
+    let res: ocrt.Value = [];
+    const mask = (1n << 64n) - 1n;
+    for (let i = 0; i < 4; ++i) {
+      res = res.concat(ocrt.bigIntToValue(value & mask));
+      value = value >> 64n;
+    }
+    return res;
   },
 };
 

--- a/runtime/src/compact-types.ts
+++ b/runtime/src/compact-types.ts
@@ -243,6 +243,9 @@ export const CompactTypeField: CompactType<bigint> = {
   },
 };
 
+/**
+ * Runtime type of the builtin `Secp256k1Base` type
+ */
 export const CompactTypeSecp256k1Base: CompactType<bigint> = {
   // Four 64-bit limbs in little-endian order.
   alignment(): ocrt.Alignment {
@@ -285,6 +288,9 @@ export const CompactTypeSecp256k1Base: CompactType<bigint> = {
   },
 };
 
+/**
+ * Runtime type of the builtin `Secp256k1Scalar` type
+ */
 export const CompactTypeSecp256k1Scalar: CompactType<bigint> = {
   // Four 64-bit limbs in little-endian order.
   alignment(): ocrt.Alignment {

--- a/runtime/src/constants.ts
+++ b/runtime/src/constants.ts
@@ -30,9 +30,21 @@ export const FIELD_MODULUS: bigint = MAX_FIELD + 1n;
 /**
  * The order of the JubJub scalar field
  */
-export const JUBJUB_SCALAR_MODULUS: bigint = 0xe7db4ea6533afa906673b0101343b00a6682093ccc81082d0970e5ed6f72cb7n;
+export const JUBJUB_SCALAR_MODULUS: bigint =
+    0xe7db4ea6533afa906673b0101343b00a6682093ccc81082d0970e5ed6f72cb7n;
 
 export const MAX_JUBJUB_SCALAR: bigint = JUBJUB_SCALAR_MODULUS - 1n;
+
+/**
+ * The maximum value of a `Secp256k1Base` foreign field value.
+ */
+export const MAX_SECP256K1_BASE: bigint = (2n**256n - 2n**32n - 977n) - 1n;
+
+/**
+ * The maximum value of a `Secp256k1Scalar` foreign field value.
+ */
+export const MAX_SECP256K1_SCALAR: bigint =
+    0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140n;
 
 /**
  * A valid placeholder contract address


### PR DESCRIPTION
They are supported in ZKIR v3 only, through to the ZKIR v3 backend.  The operations `ecAdd`, `ecMul`, and `ecMulGenerator` are implemented and generate correct ZKIR v3 output.

It's not yet implemented to extract the components of a point, nor can they appear in the ledger or be returned from witnesses.