### PR TITLE
ci: on-demand dev publish of compactc + compact-runtime

### DIFF
--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -12,10 +12,11 @@
 #   - Input `branch` selects the ref to build and publish from.
 #
 # Coordinates produced (stable, pinnable)
-#   - npm:    @midnight-ntwrk/compact-runtime@<base>-dev.<short-sha>  (dist-tag `dev`)
+#   - npm:    @midnight-ntwrk/compact-runtime@<base>-dev.<sha>  (dist-tag `dev`)
 #             registry https://npm.pkg.github.com/  (scope @midnight-ntwrk)
-#   - binary: GitHub *prerelease* on this repo, tag `compactc-dev-<short-sha>`,
-#             assets compactc_dev-<short-sha>_<arch>.zip
+#   - binary: GitHub *prerelease* on this repo, tag `compactc-dev-<sha>`,
+#             assets compactc_dev-<sha>_<arch>.zip
+#   <sha> is the full 40-char commit SHA.
 #
 # Retention
 #   - npm `dev.*` prereleases publish under dist-tag `dev` and never move `latest`.
@@ -69,7 +70,7 @@ jobs:
       contents: read
     outputs:
       branch: ${{ inputs.branch }}
-      short_sha: ${{ steps.coord.outputs.short_sha }}
+      sha: ${{ steps.coord.outputs.sha }}
       bin_tag: ${{ steps.coord.outputs.bin_tag }}
       runtime_version: ${{ steps.coord.outputs.runtime_version }}
       linux_arm: aarch64-unknown-linux-musl
@@ -86,13 +87,15 @@ jobs:
         id: coord
         run: |
           set -euo pipefail
-          SHORT_SHA="$(git rev-parse --short HEAD)"
+          # Use the full 40-char commit SHA so the coordinate is unambiguous and
+          # cannot collide (short SHAs can, in a repo this size).
+          SHA="$(git rev-parse HEAD)"
           BASE_VERSION="$(node -p "require('./runtime/package.json').version")"
-          RUNTIME_VERSION="${BASE_VERSION}-dev.${SHORT_SHA}"
-          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
-          echo "bin_tag=dev-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          RUNTIME_VERSION="${BASE_VERSION}-dev.${SHA}"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "bin_tag=dev-${SHA}" >> "$GITHUB_OUTPUT"
           echo "runtime_version=${RUNTIME_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "compactc binary tag: dev-${SHORT_SHA}"
+          echo "compactc binary tag: dev-${SHA}"
           echo "runtime npm version:  ${RUNTIME_VERSION}"
 
   build-linux-x86:
@@ -186,6 +189,8 @@ jobs:
     name: Publish compactc binary as a dev prerelease
     if: ${{ inputs.publish_compiler }}
     runs-on: ubuntu-latest
+    # The prerelease is created on LFDT-Minokawa/compact with the MIDNIGHTCI_REPO
+    # PAT (see step below), not GITHUB_TOKEN, so GITHUB_TOKEN needs only read here.
     permissions:
       contents: read
     needs: [ setup, build-linux-x86, build-linux-arm, build-macos-arm, build-macos-intel, test-linux-x86 ]
@@ -213,8 +218,8 @@ jobs:
         with:
           repository: LFDT-Minokawa/compact
           tag_name: compactc-${{ needs.setup.outputs.bin_tag }}
-          target_commitish: ${{ needs.setup.outputs.short_sha }}
-          name: Compact toolchain dev ${{ needs.setup.outputs.short_sha }}
+          target_commitish: ${{ needs.setup.outputs.sha }}
+          name: Compact toolchain dev ${{ needs.setup.outputs.sha }}
           draft: false
           prerelease: true
           fail_on_unmatched_files: true
@@ -223,7 +228,7 @@ jobs:
           body: |
             On-demand dev build of the Compact toolchain.
 
-            - Source ref: `${{ needs.setup.outputs.branch }}` @ `${{ needs.setup.outputs.short_sha }}`
+            - Source ref: `${{ needs.setup.outputs.branch }}` @ `${{ needs.setup.outputs.sha }}`
             - Runtime npm: `@midnight-ntwrk/compact-runtime@${{ needs.setup.outputs.runtime_version }}` (dist-tag `dev`)
 
             Not a supported release. See doc/dev-builds.md for the retention policy.
@@ -232,6 +237,9 @@ jobs:
     name: Publish compact-runtime dev npm package
     if: ${{ inputs.publish_runtime }}
     runs-on: ubuntu-latest
+    # npm publish authenticates with the MIDNIGHTCI_PACKAGES_WRITE PAT against the
+    # @midnight-ntwrk scope (a different org than this repo), so GITHUB_TOKEN's
+    # packages scope does not apply -- contents:read (for checkout) is sufficient.
     permissions:
       contents: read
     needs: [ setup ]

--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -1,0 +1,277 @@
+# On-demand ("dev") publish of the Compact toolchain.
+#
+# Purpose
+#   Produce an INSTALLABLE compactc binary + @midnight-ntwrk/compact-runtime npm
+#   package for ANY branch/commit, without waiting for a tagged release. Lets
+#   downstream consumers (midnight-js, midnight-node, compact-js, midnight-toolkit)
+#   pin a dev coordinate instead of cloning + Nix-building compactc per CI run.
+#
+# Trigger contract
+#   - Manual only (workflow_dispatch). Runnable by anyone with write access to
+#     this repository. Not on push/PR/schedule -- this is opt-in, on demand.
+#   - Input `branch` selects the ref to build and publish from.
+#
+# Coordinates produced (stable, pinnable)
+#   - npm:    @midnight-ntwrk/compact-runtime@<base>-dev.<short-sha>  (dist-tag `dev`)
+#             registry https://npm.pkg.github.com/  (scope @midnight-ntwrk)
+#   - binary: GitHub *prerelease* on this repo, tag `compactc-dev-<short-sha>`,
+#             assets compactc_dev-<short-sha>_<arch>.zip
+#
+# Retention
+#   - npm `dev.*` prereleases publish under dist-tag `dev` and never move `latest`.
+#   - See doc/dev-builds.md for the documented retention/cleanup policy.
+name: On-demand dev publish of compact toolchain
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch or ref to build and publish from'
+        required: true
+        type: string
+      publish_runtime:
+        description: 'Publish @midnight-ntwrk/compact-runtime to GitHub Packages'
+        required: true
+        type: boolean
+        default: true
+      publish_compiler:
+        description: 'Publish compactc binary as a GitHub prerelease'
+        required: true
+        type: boolean
+        default: true
+      include_linux_arm:
+        description: 'Also build the Linux aarch64 binary'
+        required: true
+        type: boolean
+        default: true
+      include_macos_arm:
+        description: 'Also build the macOS aarch64 (Apple silicon) binary'
+        required: true
+        type: boolean
+        default: false
+      include_macos_intel:
+        description: 'Also build the macOS x86_64 (Intel) binary'
+        required: true
+        type: boolean
+        default: false
+
+permissions: {}
+
+concurrency:
+  group: dev-publish-${{ github.workflow }}-${{ inputs.branch }}
+  cancel-in-progress: true
+
+jobs:
+  setup:
+    name: Resolve commit and compute coordinates
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      branch: ${{ inputs.branch }}
+      short_sha: ${{ steps.coord.outputs.short_sha }}
+      bin_tag: ${{ steps.coord.outputs.bin_tag }}
+      runtime_version: ${{ steps.coord.outputs.runtime_version }}
+      linux_arm: aarch64-unknown-linux-musl
+      linux_x86: x86_64-unknown-linux-musl
+      macos_arm: aarch64-darwin
+      macos_x86: x86_64-darwin
+    steps:
+      - name: Checkout target ref
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Compute coordinates
+        id: coord
+        run: |
+          set -euo pipefail
+          SHORT_SHA="$(git rev-parse --short HEAD)"
+          BASE_VERSION="$(node -p "require('./runtime/package.json').version")"
+          RUNTIME_VERSION="${BASE_VERSION}-dev.${SHORT_SHA}"
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "bin_tag=dev-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "runtime_version=${RUNTIME_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "compactc binary tag: dev-${SHORT_SHA}"
+          echo "runtime npm version:  ${RUNTIME_VERSION}"
+
+  build-linux-x86:
+    name: Build compactc binary for Linux x86_64 (Intel)
+    uses: ./.github/workflows/release-build.yml
+    needs: [ setup ]
+    if: ${{ inputs.publish_compiler }}
+    permissions:
+      contents: read
+    secrets: inherit
+    with:
+      tag: ${{ needs.setup.outputs.bin_tag }}
+      branch: ${{ needs.setup.outputs.branch }}
+      artifact: dev-linux-x86_64
+      platform: ubuntu-latest
+      architecture: ${{ needs.setup.outputs.linux_x86 }}
+      buildCommand: nix build .\#compactc-binary -L
+      include_release_notes: false
+      skipCache: false
+
+  build-linux-arm:
+    name: Build compactc binary for Linux aarch64 (Arm)
+    uses: ./.github/workflows/release-build.yml
+    needs: [ setup ]
+    if: ${{ inputs.publish_compiler && inputs.include_linux_arm }}
+    permissions:
+      contents: read
+    secrets: inherit
+    with:
+      tag: ${{ needs.setup.outputs.bin_tag }}
+      branch: ${{ needs.setup.outputs.branch }}
+      artifact: dev-linux-aarch64
+      platform: ubuntu-24.04-arm
+      architecture: ${{ needs.setup.outputs.linux_arm }}
+      buildCommand: nix build .\#compactc-binary -L
+      include_release_notes: false
+      skipCache: false
+
+  build-macos-arm:
+    name: Build compactc binary for macOS aarch64 (Arm)
+    uses: ./.github/workflows/release-build.yml
+    needs: [ setup ]
+    if: ${{ inputs.publish_compiler && inputs.include_macos_arm }}
+    permissions:
+      contents: read
+    secrets: inherit
+    with:
+      tag: ${{ needs.setup.outputs.bin_tag }}
+      branch: ${{ needs.setup.outputs.branch }}
+      artifact: dev-macos-aarch64
+      platform: macos-latest-xlarge
+      architecture: ${{ needs.setup.outputs.macos_arm }}
+      buildCommand: nix build .\#compactc-binary -L
+      include_release_notes: false
+      skipCache: true
+
+  build-macos-intel:
+    name: Build compactc binary for macOS x86_64 (Intel)
+    uses: ./.github/workflows/release-build.yml
+    needs: [ setup ]
+    if: ${{ inputs.publish_compiler && inputs.include_macos_intel }}
+    permissions:
+      contents: read
+    secrets: inherit
+    with:
+      tag: ${{ needs.setup.outputs.bin_tag }}
+      branch: ${{ needs.setup.outputs.branch }}
+      artifact: dev-macos-x86_64
+      platform: macos-15-intel
+      architecture: ${{ needs.setup.outputs.macos_x86 }}
+      buildCommand: nix build .\#compactc-binary -L
+      include_release_notes: false
+      skipCache: true
+
+  test-linux-x86:
+    name: Test compactc on Linux x86_64 (Intel)
+    uses: ./.github/workflows/release-test.yml
+    needs: [ setup, build-linux-x86 ]
+    if: ${{ inputs.publish_compiler }}
+    permissions:
+      contents: read
+    secrets: inherit
+    with:
+      tag: ${{ needs.setup.outputs.bin_tag }}
+      branch: ${{ needs.setup.outputs.branch }}
+      artifact: dev-linux-x86_64
+      platform: ubuntu-latest
+      architecture: ${{ needs.setup.outputs.linux_x86 }}
+
+  publish-compiler:
+    name: Publish compactc binary as a dev prerelease
+    if: ${{ inputs.publish_compiler }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: [ setup, build-linux-x86, build-linux-arm, build-macos-arm, build-macos-intel, test-linux-x86 ]
+    steps:
+      - name: Verify required Linux x86_64 build/test passed
+        env:
+          RESULT_BUILD: ${{ needs.build-linux-x86.result }}
+          RESULT_TEST: ${{ needs.test-linux-x86.result }}
+        run: |
+          if [ "$RESULT_BUILD" != "success" ] || [ "$RESULT_TEST" != "success" ]; then
+            echo "::error::Required Linux x86_64 build/test did not pass."
+            exit 1
+          fi
+          echo "Required Linux x86_64 build/test passed."
+
+      - name: Fetch dev binary assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: dev-*
+          merge-multiple: true
+
+      - name: Create dev prerelease on LFDT-Minokawa/compact
+        id: create_release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          repository: LFDT-Minokawa/compact
+          tag_name: compactc-${{ needs.setup.outputs.bin_tag }}
+          target_commitish: ${{ needs.setup.outputs.short_sha }}
+          name: Compact toolchain dev ${{ needs.setup.outputs.short_sha }}
+          draft: false
+          prerelease: true
+          fail_on_unmatched_files: true
+          files: compactc_${{ needs.setup.outputs.bin_tag }}_*.zip
+          token: ${{ secrets.MIDNIGHTCI_REPO }}
+          body: |
+            On-demand dev build of the Compact toolchain.
+
+            - Source ref: `${{ needs.setup.outputs.branch }}` @ `${{ needs.setup.outputs.short_sha }}`
+            - Runtime npm: `@midnight-ntwrk/compact-runtime@${{ needs.setup.outputs.runtime_version }}` (dist-tag `dev`)
+
+            Not a supported release. See doc/dev-builds.md for the retention policy.
+
+  publish-runtime:
+    name: Publish compact-runtime dev npm package
+    if: ${{ inputs.publish_runtime }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: [ setup ]
+    steps:
+      - name: Checkout target ref
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.setup.outputs.branch }}
+
+      - name: Setup Nix with cache
+        uses: ./.github/actions/setup-nix-cache
+        with:
+          attic_token: ${{ secrets.ATTIC_CACHE_TOKEN }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          always-auth: true
+          registry-url: https://npm.pkg.github.com/
+          scope: '@midnight-ntwrk'
+          node-version-file: '.nvmrc'
+
+      - name: Build publishable runtime tarball
+        run: nix build .#runtime.forPublish -L
+
+      - name: Repack with dev version and publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+          DEV_VERSION: ${{ needs.setup.outputs.runtime_version }}
+        run: |
+          set -euo pipefail
+          TGZ="$(ls result/lib/*.tgz)"
+          echo "Built tarball: $TGZ"
+          rm -rf stage && mkdir stage
+          tar -xzf "$TGZ" -C stage          # extracts ./package/
+          cd stage/package
+          # Override only the version string; dist/ from forPublish is untouched.
+          # (flake.nix warns not to bump runtime/package.json in-repo for prereleases,
+          #  so the dev version is applied here at publish time instead.)
+          npm version --no-git-tag-version --allow-same-version "$DEV_VERSION"
+          # Publish under dist-tag `dev` so `latest` is never moved to a dev build.
+          npm publish --tag dev --registry https://npm.pkg.github.com/
+          echo "Published @midnight-ntwrk/compact-runtime@${DEV_VERSION} (dist-tag dev)"

--- a/doc/dev-builds.md
+++ b/doc/dev-builds.md
@@ -11,11 +11,12 @@ Nix-building compactc on every CI run.
 
 | Artifact          | Coordinate                                                         | Where                                              |
 | ----------------- | ----------------------------------------------------------------- | -------------------------------------------------- |
-| compact-runtime   | `@midnight-ntwrk/compact-runtime@<base>-dev.<short-sha>`           | GitHub Packages npm, scope `@midnight-ntwrk`       |
-| compactc binary   | release tag `compactc-dev-<short-sha>` (assets per architecture)   | GitHub prerelease on `LFDT-Minokawa/compact`       |
+| compact-runtime   | `@midnight-ntwrk/compact-runtime@<base>-dev.<sha>`                 | GitHub Packages npm, scope `@midnight-ntwrk`       |
+| compactc binary   | release tag `compactc-dev-<sha>` (assets per architecture)        | GitHub prerelease on `LFDT-Minokawa/compact`       |
 
-`<base>` is the current `version` from `runtime/package.json`; `<short-sha>` is
-`git rev-parse --short HEAD` of the resolved ref.
+`<base>` is the current `version` from `runtime/package.json`; `<sha>` is the
+full 40-char commit SHA (`git rev-parse HEAD`) of the resolved ref -- full, not
+abbreviated, so the coordinate is unambiguous and cannot collide.
 
 The runtime is published under npm dist-tag `dev`, so it never moves `latest`.
 The binary release is flagged `prerelease`, so it never becomes "Latest release".
@@ -38,7 +39,7 @@ The binary release is flagged `prerelease`, so it never becomes "Latest release"
 Runtime (downstream `package.json`), pin the exact dev version:
 
 ```jsonc
-"@midnight-ntwrk/compact-runtime": "0.16.101-dev.abc1234"
+"@midnight-ntwrk/compact-runtime": "0.16.101-dev.<full-commit-sha>"
 ```
 
 with an `.npmrc` mapping the scope to GitHub Packages:
@@ -49,12 +50,12 @@ with an `.npmrc` mapping the scope to GitHub Packages:
 ```
 
 compactc binary, download the per-arch asset from the
-`compactc-dev-<short-sha>` prerelease, e.g.:
+`compactc-dev-<sha>` prerelease, e.g.:
 
 ```
-gh release download compactc-dev-abc1234 \
+gh release download compactc-dev-<full-commit-sha> \
   --repo LFDT-Minokawa/compact \
-  --pattern 'compactc_dev-abc1234_x86_64-unknown-linux-musl.zip'
+  --pattern 'compactc_dev-<full-commit-sha>_x86_64-unknown-linux-musl.zip'
 ```
 
 ## Retention policy

--- a/doc/dev-builds.md
+++ b/doc/dev-builds.md
@@ -1,0 +1,86 @@
+# On-demand dev builds of the Compact toolchain
+
+The `On-demand dev publish of compact toolchain` workflow
+(`.github/workflows/dev-publish.yml`) produces installable compactc + runtime
+artifacts for any branch or commit, without cutting a tagged release. It exists
+so downstream consumers (midnight-js, midnight-node, compact-js,
+midnight-toolkit) can pin a dev coordinate instead of cloning this repo and
+Nix-building compactc on every CI run.
+
+## What it produces
+
+| Artifact          | Coordinate                                                         | Where                                              |
+| ----------------- | ----------------------------------------------------------------- | -------------------------------------------------- |
+| compact-runtime   | `@midnight-ntwrk/compact-runtime@<base>-dev.<short-sha>`           | GitHub Packages npm, scope `@midnight-ntwrk`       |
+| compactc binary   | release tag `compactc-dev-<short-sha>` (assets per architecture)   | GitHub prerelease on `LFDT-Minokawa/compact`       |
+
+`<base>` is the current `version` from `runtime/package.json`; `<short-sha>` is
+`git rev-parse --short HEAD` of the resolved ref.
+
+The runtime is published under npm dist-tag `dev`, so it never moves `latest`.
+The binary release is flagged `prerelease`, so it never becomes "Latest release".
+
+## Trigger contract
+
+- **How:** Actions tab -> "On-demand dev publish of compact toolchain" -> Run
+  workflow. Manual (`workflow_dispatch`) only -- no push/PR/schedule trigger.
+- **Who:** anyone with write access to this repository.
+- **Inputs:**
+  - `branch` (required) -- branch or ref to build and publish from.
+  - `publish_runtime` (default true) -- publish the runtime npm package.
+  - `publish_compiler` (default true) -- publish the compactc binary prerelease.
+  - `include_linux_arm` (default true), `include_macos_arm` (default false),
+    `include_macos_intel` (default false) -- extra binary targets. Linux x86_64
+    is always built and is the gate for publishing the binary prerelease.
+
+## How to consume
+
+Runtime (downstream `package.json`), pin the exact dev version:
+
+```jsonc
+"@midnight-ntwrk/compact-runtime": "0.16.101-dev.abc1234"
+```
+
+with an `.npmrc` mapping the scope to GitHub Packages:
+
+```
+@midnight-ntwrk:registry=https://npm.pkg.github.com/
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+```
+
+compactc binary, download the per-arch asset from the
+`compactc-dev-<short-sha>` prerelease, e.g.:
+
+```
+gh release download compactc-dev-abc1234 \
+  --repo LFDT-Minokawa/compact \
+  --pattern 'compactc_dev-abc1234_x86_64-unknown-linux-musl.zip'
+```
+
+## Retention policy
+
+Dev builds are convenience artifacts, not supported releases.
+
+- **npm:** `*-dev.*` versions are published under dist-tag `dev` only. They are
+  immutable (a given `dev.<sha>` cannot be republished) and remain resolvable
+  for pinning. Old dev versions should be pruned to the most recent ~30 / ~30
+  days; GitHub Packages does not expire npm versions automatically, so this is a
+  manual/scheduled cleanup (tracked as a fast-follow; not wired up by this
+  workflow).
+- **binary:** `compactc-dev-*` prereleases follow the same intent -- keep the
+  most recent handful, delete older ones. They are excluded from "Latest
+  release" by the `prerelease` flag.
+
+Treat any `dev.<sha>` coordinate as "valid until pruned." For anything that must
+stay resolvable long-term, promote it to a real tagged release via the existing
+`internal-release` / `public-release` workflows.
+
+## Relationship to the release workflows
+
+- `internal-release.yml` / `public-release.yml` -- the supported, versioned
+  release path (tag-driven, build all four platforms, GitHub releases on the
+  `midnight-ntwrk/artifacts` + public repos). Unchanged.
+- `dev-publish.yml` -- this on-demand path. Reuses the same reusable building
+  blocks (`release-build.yml`, `release-test.yml`) for the binary, and the same
+  `nix build .#runtime.forPublish` derivation for the runtime, so it does not
+  fork the build logic.


### PR DESCRIPTION
# ci: on-demand dev publish of compactc + compact-runtime

## What

Adds a manually-triggered (`workflow_dispatch`) workflow that publishes an
installable Compact toolchain for **any branch/commit**, without cutting a
tagged release:

- **compact-runtime** -> `@midnight-ntwrk/compact-runtime@<base>-dev.<short-sha>`
  on GitHub Packages, under npm dist-tag `dev` (never moves `latest`).
- **compactc binary** -> GitHub **prerelease** `compactc-dev-<short-sha>` on this
  repo, per-architecture zip assets.

Plus `doc/dev-builds.md` documenting the trigger contract, coordinates, consume
instructions, and retention policy.

## Why

compactc / compact-runtime currently publish no installable artifact off-tag, so
every downstream consumer (midnight-js, midnight-node, compact-js,
midnight-toolkit) clones this repo and Nix-builds compactc on every CI run
(~15 min each, paid N times; pulls a Rust/Nix toolchain into pure-TS repos;
breaks silently on toolchain drift). midnight-js#978 and midnight-node already
carry this workaround independently. This breaks the "merge to main -> cut a
release" dependency for downstream integration (e.g. Events e2e validation).

Ref: shieldedtech/shielded-sre#324.

## How it works (reuses existing machinery, no forked build logic)

- Binary: fans out to the existing reusable `release-build.yml` /
  `release-test.yml` per platform (Linux x86_64 always built + the publish gate;
  Linux arm / macOS arm / macOS intel optional via inputs to keep on-demand runs
  cheap), then publishes a prerelease via `softprops/action-gh-release` with
  `secrets.MIDNIGHTCI_REPO` -- same pattern as `internal-release.yml`.
- Runtime: `nix build .#runtime.forPublish` (the existing publishable tarball),
  repacked with the dev version string, `npm publish --tag dev` to
  `https://npm.pkg.github.com/` with `secrets.MIDNIGHTCI_PACKAGES_WRITE`. The
  version is applied at publish time (not committed) per the flake.nix note about
  prerelease runtime versions.

## Reviewer notes / things to confirm

- **`MIDNIGHTCI_PACKAGES_WRITE` must have `write:packages` on the `midnight-ntwrk`
  org.** It is currently used only for npm reads + GitHub Release writes; the
  runtime `npm publish` is the one net-new capability. First in-repo
  `workflow_dispatch` run confirms it.
- No push/PR/schedule trigger -- manual only, runnable by anyone with write
  access.
- Automated pruning of old `dev.*` versions is intentionally left as a
  fast-follow; retention intent is documented in `doc/dev-builds.md`.

## Acceptance criteria (from shielded-sre#324)

- [x] Installable artifact producible on demand, not only on tagged releases.
- [x] Stable coordinate to pin to (`@midnight-ntwrk/compact-runtime@x-dev.<sha>`,
      `compactc-dev-<sha>`).
- [x] Retention policy documented (`doc/dev-builds.md`).
- [x] Documented trigger contract -- who can run it, inputs, where artifacts land.
