### PR TITLE
ci: fix dev-publish runtime publish path (forPublish is a dir, not a tgz)

### DIFF
--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -262,23 +262,29 @@ jobs:
           scope: '@midnight-ntwrk'
           node-version-file: '.nvmrc'
 
-      - name: Build publishable runtime tarball
+      - name: Build publishable runtime
         run: nix build .#runtime.forPublish -L
 
-      - name: Repack with dev version and publish
+      - name: Set dev version and publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
           DEV_VERSION: ${{ needs.setup.outputs.runtime_version }}
         run: |
           set -euo pipefail
-          TGZ="$(ls result/lib/*.tgz)"
-          echo "Built tarball: $TGZ"
-          rm -rf stage && mkdir stage
-          tar -xzf "$TGZ" -C stage          # extracts ./package/
-          cd stage/package
-          # Override only the version string; dist/ from forPublish is untouched.
-          # (flake.nix warns not to bump runtime/package.json in-repo for prereleases,
-          #  so the dev version is applied here at publish time instead.)
+          # `forPublish` produces a publish-ready package *directory* (with the
+          # publish package.json), not a tarball:
+          #   result/lib/node_modules/<scope>/<name>/   (see nix/pretzel/js.nix).
+          PKG_DIR="result/lib/node_modules/@midnight-ntwrk/compact-runtime"
+          if [ ! -d "$PKG_DIR" ]; then
+            echo "::error::runtime package not found at $PKG_DIR; tree was:"
+            find result/lib -maxdepth 4 -name package.json -print || true
+            exit 1
+          fi
+          # Copy out of the read-only nix store so `npm version` can rewrite package.json.
+          rm -rf stage && cp -rL "$PKG_DIR" stage && chmod -R u+w stage
+          cd stage
+          # Apply the dev version at publish time -- flake.nix warns not to bump
+          # runtime/package.json in-repo for prereleases.
           npm version --no-git-tag-version --allow-same-version "$DEV_VERSION"
           # Publish under dist-tag `dev` so `latest` is never moved to a dev build.
           npm publish --tag dev --registry https://npm.pkg.github.com/


### PR DESCRIPTION
## What

Fixes the `publish-runtime` job in `dev-publish.yml`. The first on-demand run (run [27751425579](https://github.com/LFDT-Minokawa/compact/actions/runs/27751425579)) failed at the very first line of the publish step:

```
ls: cannot access 'result/lib/*.tgz': No such file or directory
##[error]Process completed with exit code 2.
```

## Root cause

The build step succeeded -- `nix build .#runtime.forPublish` worked. The bug was a wrong assumption about its output. `forPublish` produces a **publish-ready package directory** (with the publish `package.json`), not a tarball:

```
result/lib/node_modules/@midnight-ntwrk/compact-runtime/
```

(see `nix/pretzel/js.nix` -- the `.tgz` only exists in the separate `package` derivation, and its `package.json` is not the publish one.)

## Fix

Publish directly from that directory: copy it out of the read-only nix store, apply the dev version with `npm version --no-git-tag-version`, then `npm publish --tag dev`. Adds a guard that prints the tree and fails clearly if the expected path is ever missing.

## Note

The previous run failed **before** `npm publish`, so whether `MIDNIGHTCI_PACKAGES_WRITE` has `write:packages` on `midnight-ntwrk` is still unconfirmed -- this run will reach the publish call and tell us.

Follow-up to #497.