### PR TITLE
docs(ledger-adt): clarify MerkleTree insertHash vs insert and the path-root pairing

### DIFF
--- a/doc/ledger-adt.mdx
+++ b/doc/ledger-adt.mdx
@@ -508,7 +508,11 @@ Inserts a new leaf at the first free index in this Merkle tree.
 insertHash(hash: Bytes<32>): []
 ```
 
-Inserts a new leaf with a given hash at the first free index in this Merkle tree.
+Inserts a new leaf with a precomputed hash at the first free index in this Merkle tree. Unlike [`insert`](#insert), which hashes `item` before insertion, `insertHash` stores the supplied `hash` as the leaf value without further hashing.
+
+Use `insertHash` when you commit a value off-chain and want only its hash to enter the tree. This preserves the privacy of the underlying value: the tree holds the commitment, and a witness proves membership of the corresponding preimage without revealing it on chain.
+
+When you prove membership of an `insertHash` leaf, derive the path root with [`merkleTreePathRootNoLeafHash`](../../standard-library/exports.md#merkletreepathrootnoleafhash) from `CompactStandardLibrary`, not [`merkleTreePathRoot`](../../standard-library/exports.md#merkletreepathroot). The latter would re-hash an already-hashed leaf and produce a root that does not match the tree. See [issue #63](https://github.com/midnightntwrk/midnight-docs/issues/63) for the original report.
 
 ### insertHashIndex
 
@@ -516,7 +520,7 @@ Inserts a new leaf with a given hash at the first free index in this Merkle tree
 insertHashIndex(hash: Bytes<32>, index: Uint<64>): []
 ```
 
-Inserts a new leaf with a given hash at a specific index in this Merkle tree.
+Inserts a new leaf with a precomputed hash at a specific index in this Merkle tree. Behaves like [`insertHash`](#inserthash) with respect to hashing: the supplied `hash` is stored as-is, without further hashing. Pair with [`merkleTreePathRootNoLeafHash`](../../standard-library/exports.md#merkletreepathrootnoleafhash) when verifying membership of the resulting path.
 
 ### insertIndex
 
@@ -620,7 +624,11 @@ Inserts a new leaf at the first free index in this Merkle tree.
 insertHash(hash: Bytes<32>): []
 ```
 
-Inserts a new leaf with a given hash at the first free index in this Merkle tree.
+Inserts a new leaf with a precomputed hash at the first free index in this Merkle tree. Unlike [`insert`](#insert), which hashes `item` before insertion, `insertHash` stores the supplied `hash` as the leaf value without further hashing.
+
+Use `insertHash` when you commit a value off-chain and want only its hash to enter the tree. This preserves the privacy of the underlying value: the tree holds the commitment, and a witness proves membership of the corresponding preimage without revealing it on chain.
+
+When you prove membership of an `insertHash` leaf, derive the path root with [`merkleTreePathRootNoLeafHash`](../../standard-library/exports.md#merkletreepathrootnoleafhash) from `CompactStandardLibrary`, not [`merkleTreePathRoot`](../../standard-library/exports.md#merkletreepathroot). The latter would re-hash an already-hashed leaf and produce a root that does not match the tree. See [issue #63](https://github.com/midnightntwrk/midnight-docs/issues/63) for the original report.
 
 ### insertHashIndex
 
@@ -628,7 +636,7 @@ Inserts a new leaf with a given hash at the first free index in this Merkle tree
 insertHashIndex(hash: Bytes<32>, index: Uint<64>): []
 ```
 
-Inserts a new leaf with a given hash at a specific index in this Merkle tree.
+Inserts a new leaf with a precomputed hash at a specific index in this Merkle tree. Behaves like [`insertHash`](#inserthash) with respect to hashing: the supplied `hash` is stored as-is, without further hashing. Pair with [`merkleTreePathRootNoLeafHash`](../../standard-library/exports.md#merkletreepathrootnoleafhash) when verifying membership of the resulting path.
 
 ### insertIndex
 


### PR DESCRIPTION
## Summary

The `insertHash` and `insertHashIndex` docstrings in `doc/ledger-adt.mdx` describe themselves as 'Inserts a new leaf with a given hash at the first free index in this Merkle tree' — the same wording as `insert`, with no mention of what actually happens to the supplied hash. This ambiguity was raised in midnightntwrk/midnight-docs#63 (labeled `IN PROGRESS` since December 2025).

## The gap

- `insert(item)` hashes `item` before insertion.
- `insertHash(hash)` stores the supplied `Bytes<32>` as the leaf value without further hashing.

The `hash` parameter is the **leaf value**, not a digest that gets re-hashed. This matters for two reasons:

1. **Privacy use case:** callers commit a value off-chain and want only its hash to enter the tree, so a witness can prove membership of the preimage without revealing it on chain.
2. **Path-root pairing:** when verifying membership of an `insertHash` leaf, the path must be reduced with `merkleTreePathRootNoLeafHash` from `CompactStandardLibrary`, **not** `merkleTreePathRoot`. The latter hashes the leaf once more and produces a root that does not match the tree.

## Change

- Rewrites the `insertHash` description in the `MerkleTree<nat, value_type>` section to explain the no-rehash behavior, the privacy use case, and the required `merkleTreePathRootNoLeafHash` pairing.
- Applies the same clarification to `insertHashIndex`.
- Mirrors the change in the parallel `HistoricMerkleTree<nat, value_type>` section (same empty description, same API).
- Links to midnightntwrk/midnight-docs#63 for traceability.

## Verification

- Doc-only change. `nix build` and the compiler test suite are not exercised.
- Verified the sibling explanation already exists in `docs/compact/standard-library/exports.md` for `merkleTreePathRootNoLeafHash` ('this variant assumes that the tree leaves have already been hashed externally'). The two docstrings now agree.
- This file is consumed by the midnight-docs copy workflow (see `.github/workflows/apis.yml`), so the change will propagate to `docs.midnight.network` after merge.

Closes midnightntwrk/midnight-docs#63