### PR TITLE
Group dependabot updates and security fixes by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,15 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      github-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      github-actions-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: "cargo"
     directory: "/"
@@ -14,6 +23,15 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      cargo-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      cargo-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: "npm"
     directories:
@@ -29,10 +47,14 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      npm-all:
+      npm-security:
+        applies-to: security-updates
         patterns:
           - "*"
-        group-by: dependency-name
+      npm-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
 
 #  - package-ecosystem: "docker"
 #    directory: "/"


### PR DESCRIPTION
Give each ecosystem (github-actions, cargo, npm) a security-updates group and a version-updates group so fixes land as grouped PRs. Replaces the invalid npm group-by key.