### PR TITLE
fix(events): serialize ShieldedReceive fields in the CoIP-442/MIP-0002 order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Toolchain 0.33.100, language 0.25.100, runtime 0.18.0]
 
+### Fixed
+
+- The `ShieldedReceive` standard event now serializes its fields in the order
+  specified by CoIP-442 and MIP-0002: `commitment`, `ciphertext`,
+  `contractAddress` (previously `contractAddress` preceded `ciphertext`).
+  Serialized size is unchanged (578). Fixes #590.
+
 ### Changed
 
 - The standard library ECDSA circuits `secp256k1EcdsaVerify` and

--- a/compiler/midnight-events.ss
+++ b/compiler/midnight-events.ss
@@ -20,8 +20,8 @@
 (declare-event-type ShieldedReceive 1 578
   "A contract accepts an incoming shielded coin.\n`contractAddress` set when received by a contract, absent for user recipients."
   ([commitment (Bytes 32) (hint "indexed")]
-   [contractAddress (TypeRef Maybe (Bytes 32))]
-   [ciphertext (TypeRef Maybe (Bytes 512))]))
+   [ciphertext (TypeRef Maybe (Bytes 512))]
+   [contractAddress (TypeRef Maybe (Bytes 32))]))
 
 (declare-event-type ShieldedMint 2 81
   "New shielded tokens created.\n`tokenType` derived by the consumer from `domainSep` + `ContractLog.address`."

--- a/compiler/test.ss
+++ b/compiler/test.ss
@@ -34531,12 +34531,12 @@ groups than for single tests.
              (tbytes 578)
           (let* ([[%t.3 (tstruct Maybe
                           (is_some (tboolean))
-                          (value (tbytes 32)))]
-                  (elt-ref %value.2 contractAddress 1)]
+                          (value (tbytes 512)))]
+                  (elt-ref %value.2 ciphertext 1)]
                  [[%t.4 (tstruct Maybe
                           (is_some (tboolean))
-                          (value (tbytes 512)))]
-                  (elt-ref %value.2 ciphertext 2)])
+                          (value (tbytes 32)))]
+                  (elt-ref %value.2 contractAddress 2)])
             (vector->bytes 578
               (vector
                 (spread 32
@@ -34544,11 +34544,11 @@ groups than for single tests.
                 (if (elt-ref %t.3 is_some 0)
                     (safe-cast (tunsigned 255) (tunsigned 1) 1)
                     (safe-cast (tunsigned 255) (tunsigned 0) 0))
-                (spread 32 (bytes->vector 32 (elt-ref %t.3 value 1)))
+                (spread 512 (bytes->vector 512 (elt-ref %t.3 value 1)))
                 (if (elt-ref %t.4 is_some 0)
                     (safe-cast (tunsigned 255) (tunsigned 1) 1)
                     (safe-cast (tunsigned 255) (tunsigned 0) 0))
-                (spread 512 (bytes->vector 512 (elt-ref %t.4 value 1)))))))
+                (spread 32 (bytes->vector 32 (elt-ref %t.4 value 1)))))))
         (circuit %deserialize.5 ([%value.6 (tbytes 578)])
              (tstruct ShieldedReceive
                (commitment (tbytes 32))
@@ -34569,16 +34569,16 @@ groups than for single tests.
             (bytes-slice %value.6 0 32)
             (new (tstruct Maybe
                    (is_some (tboolean))
-                   (value (tbytes 32)))
+                   (value (tbytes 512)))
               (== (bytes-ref %value.6 32)
                   (safe-cast (tunsigned 255) (tunsigned 1) 1))
-              (bytes-slice %value.6 33 32))
+              (bytes-slice %value.6 33 512))
             (new (tstruct Maybe
                    (is_some (tboolean))
-                   (value (tbytes 512)))
-              (== (bytes-ref %value.6 65)
+                   (value (tbytes 32)))
+              (== (bytes-ref %value.6 545)
                   (safe-cast (tunsigned 255) (tunsigned 1) 1))
-              (bytes-slice %value.6 66 512))))
+              (bytes-slice %value.6 546 32))))
         (circuit %deserialize_ShieldedReceive.7 ([%x.8 (tbytes
                                                          578)])
              (tstruct ShieldedReceive

--- a/compiler/test.ss
+++ b/compiler/test.ss
@@ -15040,12 +15040,12 @@ groups than for single tests.
         (export-typedef ShieldedReceive ()
           (tstruct ShieldedReceive
             (commitment (tbytes 32))
-            (contractAddress (tstruct Maybe
-                                (is_some (tboolean))
-                                (value (tbytes 32))))
             (ciphertext (tstruct Maybe
                           (is_some (tboolean))
-                          (value (tbytes 512))))))
+                          (value (tbytes 512))))
+            (contractAddress (tstruct Maybe
+                                (is_some (tboolean))
+                                (value (tbytes 32))))))
         (public-ledger-declaration %kernel.0 (Kernel))))
     )
 
@@ -34520,14 +34520,14 @@ groups than for single tests.
         (public-ledger-declaration () (constructor () (tuple)))
         (circuit %serialize.1 ([%value.2 (tstruct ShieldedReceive
                                            (commitment (tbytes 32))
-                                           (contractAddress (tstruct Maybe
-                                                               (is_some (tboolean))
-                                                               (value (tbytes
-                                                                        32))))
                                            (ciphertext (tstruct Maybe
                                                          (is_some (tboolean))
                                                          (value (tbytes
-                                                                  512)))))])
+                                                                  512))))
+                                           (contractAddress (tstruct Maybe
+                                                               (is_some (tboolean))
+                                                               (value (tbytes
+                                                                        32)))))])
              (tbytes 578)
           (let* ([[%t.3 (tstruct Maybe
                           (is_some (tboolean))
@@ -34552,20 +34552,20 @@ groups than for single tests.
         (circuit %deserialize.5 ([%value.6 (tbytes 578)])
              (tstruct ShieldedReceive
                (commitment (tbytes 32))
-               (contractAddress (tstruct Maybe
-                                   (is_some (tboolean))
-                                   (value (tbytes 32))))
                (ciphertext (tstruct Maybe
                              (is_some (tboolean))
-                             (value (tbytes 512)))))
+                             (value (tbytes 512))))
+               (contractAddress (tstruct Maybe
+                                   (is_some (tboolean))
+                                   (value (tbytes 32)))))
           (new (tstruct ShieldedReceive
                  (commitment (tbytes 32))
-                 (contractAddress (tstruct Maybe
-                                     (is_some (tboolean))
-                                     (value (tbytes 32))))
                  (ciphertext (tstruct Maybe
                                (is_some (tboolean))
-                               (value (tbytes 512)))))
+                               (value (tbytes 512))))
+                 (contractAddress (tstruct Maybe
+                                     (is_some (tboolean))
+                                     (value (tbytes 32)))))
             (bytes-slice %value.6 0 32)
             (new (tstruct Maybe
                    (is_some (tboolean))
@@ -34583,24 +34583,24 @@ groups than for single tests.
                                                          578)])
              (tstruct ShieldedReceive
                (commitment (tbytes 32))
-               (contractAddress (tstruct Maybe
-                                   (is_some (tboolean))
-                                   (value (tbytes 32))))
                (ciphertext (tstruct Maybe
                              (is_some (tboolean))
-                             (value (tbytes 512)))))
+                             (value (tbytes 512))))
+               (contractAddress (tstruct Maybe
+                                   (is_some (tboolean))
+                                   (value (tbytes 32)))))
           (call %deserialize.5 %x.8))
         (circuit %serialize_ShieldedReceive.9 ([%x.10 (tstruct ShieldedReceive
                                                         (commitment (tbytes
                                                                       32))
-                                                        (contractAddress (tstruct Maybe
-                                                                            (is_some (tboolean))
-                                                                            (value (tbytes
-                                                                                     32))))
                                                         (ciphertext (tstruct Maybe
                                                                       (is_some (tboolean))
                                                                       (value (tbytes
-                                                                               512)))))])
+                                                                               512))))
+                                                        (contractAddress (tstruct Maybe
+                                                                            (is_some (tboolean))
+                                                                            (value (tbytes
+                                                                                     32)))))])
              (tbytes 578)
           (call %serialize.1 %x.10))))
     )
@@ -88827,21 +88827,21 @@ groups than for single tests.
       "export circuit emit_one(n: Bytes<32>, c: Bytes<512>): Bytes<32> {"
       "  emit(ShieldedReceive {"
       "    commitment: disclose(n),"
-      "    contractAddress: Maybe<Bytes<32>> { is_some: true, value: disclose(n) },"
-      "    ciphertext: Maybe<Bytes<512>> { is_some: true, value: disclose(c) }"
+      "    ciphertext: Maybe<Bytes<512>> { is_some: true, value: disclose(c) },"
+      "    contractAddress: Maybe<Bytes<32>> { is_some: true, value: disclose(n) }"
       "  });"
       "  return n;"
       "}"
       "export circuit emit_two(n: Bytes<32>, c: Bytes<512>): Bytes<32> {"
       "  emit(ShieldedReceive {"
       "    commitment: disclose(n),"
-      "    contractAddress: Maybe<Bytes<32>> { is_some: true, value: disclose(n) },"
-      "    ciphertext: Maybe<Bytes<512>> { is_some: true, value: disclose(c) }"
+      "    ciphertext: Maybe<Bytes<512>> { is_some: true, value: disclose(c) },"
+      "    contractAddress: Maybe<Bytes<32>> { is_some: true, value: disclose(n) }"
       "  });"
       "  emit(ShieldedReceive {"
       "    commitment: disclose(n),"
-      "    contractAddress: Maybe<Bytes<32>> { is_some: false, value: disclose(n) },"
-      "    ciphertext: Maybe<Bytes<512>> { is_some: false, value: disclose(c) }"
+      "    ciphertext: Maybe<Bytes<512>> { is_some: false, value: disclose(c) },"
+      "    contractAddress: Maybe<Bytes<32>> { is_some: false, value: disclose(n) }"
       "  });"
       "  return n;"
       "}"
@@ -88849,8 +88849,8 @@ groups than for single tests.
       "  if (disclose(b)) {"
       "    emit(ShieldedReceive {"
       "      commitment: disclose(n),"
-      "      contractAddress: Maybe<Bytes<32>> { is_some: true, value: disclose(n) },"
-      "      ciphertext: Maybe<Bytes<512>> { is_some: true, value: disclose(c) }"
+      "      ciphertext: Maybe<Bytes<512>> { is_some: true, value: disclose(c) },"
+      "      contractAddress: Maybe<Bytes<32>> { is_some: true, value: disclose(n) }"
       "    });"
       "  }"
       "  return n;"

--- a/doc/api/CompactStandardLibrary/exports.md
+++ b/doc/api/CompactStandardLibrary/exports.md
@@ -209,8 +209,8 @@ A contract accepts an incoming shielded coin.
 ```compact
 struct ShieldedReceive {
   commitment: Bytes<32>, // indexed
-  contractAddress: Maybe<Bytes<32>>,
-  ciphertext: Maybe<Bytes<512>>
+  ciphertext: Maybe<Bytes<512>>,
+  contractAddress: Maybe<Bytes<32>>
 }
 ```
 


### PR DESCRIPTION
## Summary

`compiler/midnight-events.ss` declares `ShieldedReceive` as `(commitment, contractAddress, ciphertext)`, while CoIP-442 (since e537fc9, "Reorder ShieldedReceive fields") and MIP-0002 Appendix A specify `(commitment, ciphertext, contractAddress)`. Emitted events therefore don't match consumers that decode the specified order — the midnight-indexer does, which is how this surfaced (midnightntwrk/midnight-indexer#1311: `ciphertext` and `receivingContractAddress` mis-decode, byte-exact repro). The field order lives in exactly two places across the stack, this declaration and the indexer's decoder; compact-runtime, compact-js, the node toolkit and midnight.js carry no field-order knowledge, so no other component needs a code change.

## Changes

- `compiler/midnight-events.ss`: swap the two `Maybe` fields in the `ShieldedReceive` declaration (serialized size unchanged, 578).
- `doc/api/CompactStandardLibrary/exports.md`: align the `ShieldedReceive` struct doc.
- `compiler/test.ss`: update the six `tstruct ShieldedReceive` expectation fixtures to the new field order, and reorder the fields in the four `emit(ShieldedReceive { … })` test-source literals to match the declaration.
- `CHANGELOG.md`: entry under the unreleased toolchain 0.33.100 section.

## Notes for reviewers

- The expectation fixtures were updated structurally (field forms swapped, parenthesis balance verified); I couldn't run the compiler test suite locally, so please let CI validate, and if any expectation is pretty-printer-formatting-sensitive it may need regeneration.
- The JS-side test objects (`{ commitment: …, contractAddress: …, ciphertext: … }` in staged JS) are field-name keyed and were left as is.

Fixes #590.