### PR TITLE
fix: vim editor support

### DIFF
--- a/editor-support/vim/ftdetect/compact.vim
+++ b/editor-support/vim/ftdetect/compact.vim
@@ -13,5 +13,7 @@
 " See the License for the specific language governing permissions and
 " limitations under the License.
 
-au BufRead,BufNewFile *.compact set filetype=compact
-au FileType compact setlocal nospell
+augroup compact_ftdetect
+  autocmd!
+  autocmd BufRead,BufNewFile *.compact setf compact
+augroup END

--- a/editor-support/vim/ftplugin/compact.vim
+++ b/editor-support/vim/ftplugin/compact.vim
@@ -1,0 +1,25 @@
+" This file is part of Compact.
+" Copyright (C) 2026 contributors to Minokawa Compact
+" SPDX-License-Identifier: Apache-2.0
+" Licensed under the Apache License, Version 2.0 (the "License");
+" You may not use this file except in compliance with the License.
+" You may obtain a copy of the License at
+"
+"	http://www.apache.org/licenses/LICENSE-2.0
+"
+" Unless required by applicable law or agreed to in writing, software
+" distributed under the License is distributed on an "AS IS" BASIS,
+" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+" See the License for the specific language governing permissions and
+" limitations under the License.
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal nospell
+setlocal commentstring=//\ %s
+setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
+
+let b:undo_ftplugin = "setlocal spell< commentstring< comments<"

--- a/editor-support/vim/syntax/compact.vim
+++ b/editor-support/vim/syntax/compact.vim
@@ -17,19 +17,23 @@ if exists("b:current_syntax")
   finish
 endif
 
+" '$' is a valid identifier character (see the lexer), so it must not split a
+" word for keyword matching -- otherwise 'private$secret_key' matches 'private'.
+syn iskeyword @,48-57,_,192-255,$
+
 syn keyword compactKeyword as assert circuit constructor contract default disclose emit enum export from implements import include ledger module new pad pragma prefix pure return sealed slice struct type witness
 syn keyword compactBoolean true false
 syn keyword compactType Boolean Bytes Field JubjubScalar Opaque Secp256k1Base Secp256k1Scalar Uint Vector
 syn keyword compactType Kernel Counter Set Map List MerkleTree HistoricMerkleTree
 syn keyword compactConditional if else 
 syn keyword compactStorageClass const
-syn keyword compactFutureReservedWord this await break case catch class continue debugger delete do extends finally function in instanceof null super switch throw try typeof var void while with yield implements interface package private protected public let static
+syn keyword compactFutureReservedWord arguments await break case catch class continue debugger delete do eval event extends finally function in instanceof interface let null package private protected public static super switch this throw try typeof var void while with yield
 syn match compactOperator "="
 syn match compactOperator "+="
 syn match compactOperator "-="
 syn match compactOperator "!"
-syn match compactOperator "."
-syn match compactOperator ".."
+syn match compactOperator "\."
+syn match compactOperator "\.\.\."
 syn match compactOperator "#"
 syn match compactOperator "+"
 syn match compactOperator "*"
@@ -50,8 +54,14 @@ syn keyword compactTodo contained TODO FIXME XXX NOTE
 syn match compactComment "//.*$" contains=compactTodo
 syn region compactComment start="/\*" end="\*/" contains=compactTodo
 syn region compactString start="\"" skip="\\\\\|\\\"" end="\""
+" Catch-all so that no operator match can claim part of a word. Deliberately
+" left unlinked: identifiers are rendered as plain text.
 syn match compactIdentifier '[a-zA-Z_$][a-zA-Z0-9_$]*'
 syn match compactNumber '\d\+'
+
+" Without this, /* ... */ blocks lose their highlighting when the window is
+" scrolled into the middle of one.
+syn sync ccomment compactComment minlines=100
 
 let b:current_syntax = "compact"
 
@@ -59,6 +69,8 @@ hi def link compactKeyword Keyword
 hi def link compactBoolean Boolean
 hi def link compactType Type
 hi def link compactConditional Conditional
+" Reserved for future use: these are rejected by the compiler today.
+hi def link compactFutureReservedWord Error
 hi def link compactStorageClass StorageClass
 hi def link compactOperator Operator
 hi def link compactRepeat Repeat


### PR DESCRIPTION
# Overview

The Vim syntax file highlights incorrectly today. Two operator patterns
are unescaped:

```vim
syn match compactOperator "."      " matches ANY character
syn match compactOperator ".."     " matches ANY two characters
```

The `..` match starts one column before the word that follows it, and Vim gives priority
to the item that starts earliest — which outranks keyword priority. So it eats the first
character of most tokens and kills the match behind it:

```
export ledger round: Counter;
   ^ Keyword     l→Operator, edger→plain     C→Operator, ounter→plain
```

So `ledger` never gets its keyword highlight and `Counter` never gets its type highlight,
even though both are matched correctly by the rules — the operator match simply wins.
`compactType` effectively never applies anywhere in a real file. Escaping these to `\.`
and `\.\.\.` (the spread operator is `...`) fixes it.

## Changes

**`syntax/compact.vim`**

- Escape `.` and `..` — restores keyword, type, number and string highlighting.
- Add `hi def link compactFutureReservedWord Error` — the group was defined but never
  linked, so reserved words rendered as plain text.
- Remove `implements` from the reserved-word group; per `compiler/parser.ss` it's a
  control keyword, and it was being shadowed into the unlinked group.
- Add missing reserved words `arguments`, `eval`, `event` (from `compiler/parser.ss`).
- Add `syn iskeyword` including `$` — `$` is a valid identifier char
  (`compiler/lexer.ss`), so `private$secret_key` was matching the reserved word
  `private` and flagging valid code in `examples/election.compact` as an error.
- Add `syn sync ccomment` — without it, scrolling into a long `/* … */` block dropped
  the comment highlighting entirely (see `examples/camelCase/new/coracle.compact:185`).

**`ftdetect/compact.vim`** — wrap in an `augroup` so re-sourcing doesn't stack
autocommands, use `setf` instead of `set filetype=`, and move `setlocal nospell` into
the new ftplugin where filetype-local options belong.

**`ftplugin/compact.vim`** (new) — sets `commentstring=// %s`. Without it `gc`/`gcc`
fails with *"Option 'commentstring' is empty."* Carries the relocated
standard `b:did_ftplugin` guard and `b:undo_ftplugin`.

## Tests

Before
<img width="802" height="416" alt="image" src="https://github.com/user-attachments/assets/cce99cf9-8a51-4f3b-bcd1-99951d4e61e2" />

After
<img width="803" height="414" alt="image" src="https://github.com/user-attachments/assets/f133388b-dc53-48d0-a86b-3d8ca46ea2c1" />

