### PR TITLE
Add zero-bit compiler regressions

### DIFF
--- a/examples/bugs/issue-285/zero-maximum-ledger.compact
+++ b/examples/bugs/issue-285/zero-maximum-ledger.compact
@@ -1,0 +1,35 @@
+// This file is part of Compact.
+// Copyright (C) 2025 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export ledger F1: Uint<0..1>;
+
+export circuit foo1(x: Uint<32>): Uint<8> {
+  F1 = disclose(x) as Uint<0..1>;
+  return F1;
+}
+
+export ledger F2: Uint<0..2>;
+
+export circuit foo2(x: Uint<32>): Uint<8> {
+  F2 = disclose(x) as Uint<0..1>;
+  return F2;
+}
+
+export ledger F3: Uint<0..3>;
+
+export circuit foo3(x: Uint<32>): Uint<8> {
+  F3 = disclose(x) as Uint<0..1>;
+  return F3;
+}

--- a/examples/bugs/issue-588/attestation.compact
+++ b/examples/bugs/issue-588/attestation.compact
@@ -1,0 +1,33 @@
+// This file is part of Compact.
+// Copyright (C) 2025 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import CompactStandardLibrary;
+
+enum Kind { mint }
+
+struct Attestation {
+  kind: Kind,
+  amount: Uint<64>,
+}
+
+export ledger digest: Bytes<32>;
+export ledger value: Attestation;
+
+export circuit attest(amount: Uint<64>): Attestation {
+  const attestation = Attestation { kind: Kind.mint, amount: amount };
+  value = disclose(attestation);
+  digest = disclose(persistentHash<Attestation>(attestation));
+  return value;
+}

--- a/tests-e2e/src/tests/bugs/compiler.bugs.zero-bit.e2e.test.ts
+++ b/tests-e2e/src/tests/bugs/compiler.bugs.zero-bit.e2e.test.ts
@@ -1,0 +1,98 @@
+// This file is part of Compact.
+// Copyright (C) 2025 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Result } from 'execa';
+import { describe, expect, test } from 'vitest';
+import {
+    Arguments,
+    buildPathTo,
+    compile,
+    createTempFolder,
+    expectCompilerResult,
+    expectFiles,
+    getFileContent,
+} from '@';
+
+type Alignment = {
+    tag: string;
+    value: {
+        length: number;
+        tag: string;
+    };
+};
+
+type ZkirInstruction = {
+    op: string;
+    alignment?: Alignment[];
+    inputs?: unknown[];
+};
+
+type ZkirCircuit = {
+    version: {
+        major: number;
+    };
+    instructions: ZkirInstruction[];
+};
+
+const ZERO_MAXIMUM_LEDGER = buildPathTo('/bugs/issue-285/zero-maximum-ledger.compact');
+const ATTESTATION = buildPathTo('/bugs/issue-588/attestation.compact');
+
+function getZkir(outputDir: string, circuitName: string): ZkirCircuit {
+    return JSON.parse(getFileContent(`${outputDir}/zkir/${circuitName}.zkir`)) as ZkirCircuit;
+}
+
+function expectPersistentHashAlignment(outputDir: string, version: number): void {
+    const zkir = getZkir(outputDir, 'attest');
+    const instruction = zkir.instructions.find(({ op }) => op === 'persistent_hash');
+
+    expect(zkir.version.major).toBe(version);
+    expect(instruction).toBeDefined();
+    expect(instruction?.alignment?.map(({ value }) => value.length)).toEqual([1, 8]);
+    expect(instruction?.inputs).toHaveLength(2);
+}
+
+describe('[Bugs] Zero-bit fields use consistent one-byte alignment', () => {
+    test('[Issue #285] Uint<0..1> ledger descriptors use one byte', async () => {
+        const outputDir = createTempFolder();
+        const result: Result = await compile([Arguments.SKIP_ZK, ZERO_MAXIMUM_LEDGER, outputDir]);
+
+        expectCompilerResult(result).toCompileWithoutErrors();
+        expectFiles(outputDir).thatGeneratedJSCodeIsValid();
+
+        const generatedContract = getFileContent(`${outputDir}/contract/index.js`);
+        expect(generatedContract).toContain('new __compactRuntime.CompactTypeUnsignedInteger(0n, 1)');
+        expect(getZkir(outputDir, 'foo1').version.major).toBe(2);
+        expect(getZkir(outputDir, 'foo2').version.major).toBe(2);
+        expect(getZkir(outputDir, 'foo3').version.major).toBe(2);
+    });
+
+    test('[Issue #588] persistentHash inputs match their v2 alignment', async () => {
+        const outputDir = createTempFolder();
+        const result: Result = await compile([Arguments.SKIP_ZK, ATTESTATION, outputDir]);
+
+        expectCompilerResult(result).toCompileWithoutErrors();
+        expectFiles(outputDir).thatGeneratedJSCodeIsValid();
+        expectPersistentHashAlignment(outputDir, 2);
+    });
+
+    test('[Issue #615] the reproduction compiles with the v3 backend', async () => {
+        const outputDir = createTempFolder();
+        const result: Result = await compile([Arguments.FEATURE_V3, Arguments.SKIP_ZK, ATTESTATION, outputDir]);
+
+        expectCompilerResult(result).toCompileWithoutErrors();
+        expectFiles(outputDir).thatGeneratedJSCodeIsValid();
+        expectPersistentHashAlignment(outputDir, 3);
+    });
+});


### PR DESCRIPTION
Adds compiler E2E coverage for #285, #588, and #615.

Checks one-byte zero-value descriptors, persistent-hash alignment in ZKIR v2/v3, and the v3 backend reproduction.

Tests: lint and focused Vitest suite (3/3).
