### PR TITLE
Test secp256k1 arithmetic operators

### DIFF
--- a/examples/secp256k1/arithmetic.compact
+++ b/examples/secp256k1/arithmetic.compact
@@ -1,5 +1,5 @@
 // This file is part of Compact.
-// Copyright (C) 2025 Midnight Foundation
+// Copyright (C) 2026 Midnight Foundation
 // SPDX-License-Identifier: Apache-2.0
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/secp256k1/arithmetic.compact
+++ b/examples/secp256k1/arithmetic.compact
@@ -1,0 +1,47 @@
+// This file is part of Compact.
+// Copyright (C) 2025 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export ledger base: Secp256k1Base;
+export ledger scalar: Secp256k1Scalar;
+
+export circuit add_base(a: Secp256k1Base, b: Secp256k1Base): Secp256k1Base {
+  base = disclose(a + b);
+  return base;
+}
+
+export circuit subtract_base(a: Secp256k1Base, b: Secp256k1Base): Secp256k1Base {
+  base = disclose(a - b);
+  return base;
+}
+
+export circuit multiply_base(a: Secp256k1Base, b: Secp256k1Base): Secp256k1Base {
+  base = disclose(a * b);
+  return base;
+}
+
+export circuit add_scalar(a: Secp256k1Scalar, b: Secp256k1Scalar): Secp256k1Scalar {
+  scalar = disclose(a + b);
+  return scalar;
+}
+
+export circuit subtract_scalar(a: Secp256k1Scalar, b: Secp256k1Scalar): Secp256k1Scalar {
+  scalar = disclose(a - b);
+  return scalar;
+}
+
+export circuit multiply_scalar(a: Secp256k1Scalar, b: Secp256k1Scalar): Secp256k1Scalar {
+  scalar = disclose(a * b);
+  return scalar;
+}

--- a/tests-e2e/src/tests/compiler/compiler.secp256k1.arithmetic.e2e.test.ts
+++ b/tests-e2e/src/tests/compiler/compiler.secp256k1.arithmetic.e2e.test.ts
@@ -1,5 +1,5 @@
 // This file is part of Compact.
-// Copyright (C) 2025 Midnight Foundation
+// Copyright (C) 2026 Midnight Foundation
 // SPDX-License-Identifier: Apache-2.0
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests-e2e/src/tests/compiler/compiler.secp256k1.arithmetic.e2e.test.ts
+++ b/tests-e2e/src/tests/compiler/compiler.secp256k1.arithmetic.e2e.test.ts
@@ -1,0 +1,83 @@
+// This file is part of Compact.
+// Copyright (C) 2025 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Result } from 'execa';
+import { describe, expect, test } from 'vitest';
+import {
+    Arguments,
+    buildPathTo,
+    compile,
+    createTempFolder,
+    expectCompilerResult,
+    expectFiles,
+    getFileContent,
+} from '@';
+
+type ZkirCircuit = {
+    inputs: {
+        type: string;
+    }[];
+    outputs: string[];
+    instructions: {
+        op: string;
+    }[];
+};
+
+type ArithmeticCase = {
+    circuit: string;
+    type: string;
+    operations: string[];
+};
+
+const CONTRACT = buildPathTo('/secp256k1/arithmetic.compact');
+const cases: ArithmeticCase[] = [
+    { circuit: 'add_base', type: 'Base<Secp256k1>', operations: ['add'] },
+    { circuit: 'subtract_base', type: 'Base<Secp256k1>', operations: ['neg', 'add'] },
+    { circuit: 'multiply_base', type: 'Base<Secp256k1>', operations: ['mul'] },
+    { circuit: 'add_scalar', type: 'Scalar<Secp256k1>', operations: ['add'] },
+    { circuit: 'subtract_scalar', type: 'Scalar<Secp256k1>', operations: ['neg', 'add'] },
+    { circuit: 'multiply_scalar', type: 'Scalar<Secp256k1>', operations: ['mul'] },
+];
+
+function getZkir(outputDir: string, circuitName: string): ZkirCircuit {
+    return JSON.parse(getFileContent(`${outputDir}/zkir/${circuitName}.zkir`)) as ZkirCircuit;
+}
+
+describe('[Compiler] secp256k1 arithmetic operators', () => {
+    test('v3 emits arithmetic for base and scalar fields', async () => {
+        const outputDir = createTempFolder();
+        const result: Result = await compile([Arguments.FEATURE_V3, Arguments.SKIP_ZK, CONTRACT, outputDir]);
+
+        expectCompilerResult(result).toCompileWithoutErrors();
+        expectFiles(outputDir).thatGeneratedJSCodeIsValid();
+
+        for (const { circuit, type, operations } of cases) {
+            const zkir = getZkir(outputDir, circuit);
+            const emittedOperations = zkir.instructions.map(({ op }) => op);
+
+            expect(zkir.inputs.map((input) => input.type)).toEqual([type, type]);
+            expect(zkir.outputs).toEqual([type]);
+            expect(emittedOperations).toEqual(expect.arrayContaining(operations));
+        }
+
+        const generatedContract = getFileContent(`${outputDir}/contract/index.js`);
+        expect(generatedContract).toContain('__compactRuntime.secp256k1BaseAdd');
+        expect(generatedContract).toContain('__compactRuntime.secp256k1BaseSub');
+        expect(generatedContract).toContain('__compactRuntime.secp256k1BaseMul');
+        expect(generatedContract).toContain('__compactRuntime.secp256k1ScalarAdd');
+        expect(generatedContract).toContain('__compactRuntime.secp256k1ScalarSub');
+        expect(generatedContract).toContain('__compactRuntime.secp256k1ScalarMul');
+    });
+});


### PR DESCRIPTION
Adds compiler E2E coverage for #679.

Checks `+`, `-`, and `*` lowering for secp256k1 base and scalar fields.

Tests: lint and focused Vitest suite (1/1).
