### PR TITLE
compiler: fix incorrect comments in bytes->field guard derivation

### DIFF
--- a/compiler/circuit-passes/missing-guard-workarounds.ss
+++ b/compiler/circuit-passes/missing-guard-workarounds.ss
@@ -124,12 +124,12 @@
                         `(= 1 ,t2 (== ,triv1 ,q))
                         ;; t3 = triv2 > r
                         `(= 1 ,t3 (< ,(unsigned-bits) ,r ,triv2))
-                        ;; t4 = !(triv2 > r) && triv1 == 0
-                        ;;    = triv1 == 0 && triv2 <= r
+                        ;; t4 = !(triv2 > r) && triv1 == q
+                        ;;    = triv1 == q && triv2 <= r
                         `(= 1 ,t4 (select ,t3 0 ,t2))
-                        ;; t5 = triv1 < q || triv1 == 0 && triv2 <= r
+                        ;; t5 = triv1 < q || triv1 == q && triv2 <= r
                         `(= 1 ,t5 (select ,t1 1 ,t4))
-                        ;; t6 = !test || triv1 < q || triv1 == 0 && triv2 <= r
+                        ;; t6 = !test || triv1 < q || triv1 == q && triv2 <= r
                         `(= 1 ,t6 (select ,test ,t5 1))
                         `(assert ,src ,t6 "bytes value is too big to fit in a field")
                         ;; when bytes->field would fail, provide it something innocuous


### PR DESCRIPTION
In `missing-guard-workarounds.ss`, the comments describing the `bytes->field` guard say `triv1 == 0`, but the temporary they refer to is defined a few lines above as `triv1 == q`:

```scheme
;; t2 = triv1 == q
`(= 1 ,t2 (== ,triv1 ,q))
...
;; t4 = !(triv2 > r) && triv1 == 0    <- t4 uses t2, i.e. triv1 == q
`(= 1 ,t4 (select ,t3 0 ,t2))
```

The generated code is correct; only the comments are off. This is comment-only — no behaviour change.

Worth fixing because this pass is the workaround for zkir's non-conditional operators, and the inline derivation is the main aid for anyone auditing that arithmetic.