### PR TITLE
prepare for compactc 0.34.0-rc.1 release

### DIFF
--- a/runtime/package-lock.json
+++ b/runtime/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@midnight-ntwrk/compact-runtime",
-  "version": "0.19.0-rc.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@midnight-ntwrk/compact-runtime",
-      "version": "0.19.0-rc.0",
+      "version": "0.19.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@midnightntwrk/onchain-runtime-v4": "^4.0.0-rc.3",

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midnight-ntwrk/compact-runtime",
-  "version": "0.19.0-rc.0",
+  "version": "0.19.0",
   "description": "Compact Runtime",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Bumps the compact runtime from `0.19.0-rc.0` to `0.19.0`. This bump is required to cut `compactc 0.34.0-rc.1` which then will be copied as `compactc 0.34.0`.