### PR TITLE
docs: annotate all native types and circuits in stdlib exports

### DIFF
--- a/doc/api/CompactStandardLibrary/exports.md
+++ b/doc/api/CompactStandardLibrary/exports.md
@@ -406,6 +406,8 @@ circuit right<A, B>(value: B): Either<A, B>;
 
 ### `transientHash`
 
+This is a native circuit.
+
 Builtin transient hash compression function
 
 This function is a circuit-efficient compression function from arbitrary values
@@ -424,6 +426,8 @@ circuit transientHash<T>(value: T): Field;
 ```
 
 ### `transientCommit`
+
+This is a native circuit.
 
 Builtin transient commitment function
 
@@ -446,6 +450,8 @@ circuit transientCommit<T>(value: T, rand: Field): Field;
 
 ### `persistentHash`
 
+This is a native circuit.
+
 Builtin persistent hash compression function
 
 This function is a non-circuit-optimised compression function from arbitrary values
@@ -461,6 +467,8 @@ circuit persistentHash<T>(value: T): Bytes<32>;
 ```
 
 ### `persistentCommit`
+
+This is a native circuit.
 
 Builtin persistent commitment function
 
@@ -478,6 +486,8 @@ circuit persistentCommit<T>(value: T, rand: Bytes<32>): Bytes<32>;
 
 ### `degradeToTransient`
 
+This is a native circuit.
+
 This function "degrades" the output of a [`persistentHash`](#persistenthash)
 or [`persistentCommit`](#persistentcommit) to a field element, which can then
 be used in [`transientHash`](#transienthash) or
@@ -488,6 +498,9 @@ circuit degradeToTransient(x: Bytes<32>) : Field;
 ```
 
 ### `upgradeFromTransient`
+
+This is a native circuit.
+
 This function "upgrades" a field element to the output of a
 [`persistentHash`](#persistenthash) or [`persistentCommit`](#persistentcommit).
 
@@ -497,6 +510,8 @@ circuit upgradeFromTransient(x: Field): Bytes<32>;
 ```
 
 ### `keccak256`
+
+This is a native circuit.
 
 This function hashes its input using the Keccak-256 algorithm.  It returns the
 32-byte digest.
@@ -603,7 +618,7 @@ and (hexadecimal)
 
 ### `secp256k1PointX`
 
-This is a native type.
+This is a native circuit.
 
 This function extracts the affine x-coordinate from a
 [`Secp256k1Point`](#secp256k1point).
@@ -614,7 +629,7 @@ circuit secp256k1PointX(pt: Secp256k1Point): Secp256k1Base;
 
 ### `secp256k1PointY`
 
-This is a native type.
+This is a native circuit.
 
 This function extracts the affine y-coordinate from a
 [`Secp256k1Point`](#secp256k1point).
@@ -624,6 +639,8 @@ circuit secp256k1PointY(pt: Secp256k1Point): Secp256k1Base;
 ```
 
 ### `ecAdd`
+
+This is a native circuit.
 
 This function adds two elliptic curve points. It is polymorphic for the
 following types:
@@ -637,6 +654,8 @@ circuit ecAdd(a: Secp256k1Point, b: Secp256k1Point): Secp256k1Point;
 
 ### `ecNeg`
 
+This is a native circuit.
+
 This function negates an elliptic [`JubjubPoint`](#jubjubpoint). On the JubJub
 twisted Edwards curve, the negation of `(x, y)` is `(-x, y)`.
 
@@ -645,6 +664,8 @@ circuit ecNeg(a: JubjubPoint): JubjubPoint;
 ```
 
 ### `ecMul`
+
+This is a native circuit.
 
 This function multiplies an elliptic curve point by a scalar. It is polymorphic for the
 following types:
@@ -658,6 +679,8 @@ circuit ecMul(a: Secp256k1Point, b: Secp256k1Scalar): Secp256k1Point;
 
 ### `ecMulGenerator`
 
+This is a native circuit.
+
 This function multiplies the primary group generator of a curve by a
 scalar. It is polymorphic for the following types:
 * [`JubjubPoint`](#jubjubpoint)s
@@ -669,6 +692,8 @@ circuit ecMulGenerator(b: Secp256k1Scalar): Secp256k1Point;
 ```
 
 ### `neg`
+
+This is a native circuit.
 
 Negates a field element, i.e. returns the value `y` such that
 `add(x, y)` is `0` in the field. Polymorphic function
@@ -683,6 +708,8 @@ circuit neg(x: Secp256k1Base): Secp256k1Base;
 
 ### `inv`
 
+This is a native circuit.
+
 Returns the multiplicative inverse of a field element, i.e. the value
 `y` such that `mul(x, y)` is `1` in the field. Polymorphic function
 that works over types: 
@@ -695,6 +722,8 @@ circuit inv(x: Secp256k1Base): Secp256k1Base;
 ```
 
 ### `hashToCurve`
+
+This is a native circuit.
 
 This function maps arbitrary types to [`JubjubPoint`](#nativepoint)s.
 
@@ -895,6 +924,8 @@ circuit mergeCoinImmediate(a: QualifiedCoinInfo, b: CoinInfo): CoinInfo;
 
 ### `ownPublicKey`
 
+This is a native circuit.
+
 Returns the [`ZswapCoinPublicKey`](#zswapcoinpublickey) of the end-user
 creating this transaction.
 
@@ -903,6 +934,8 @@ circuit ownPublicKey(): ZswapCoinPublicKey;
 ```
 
 ### `createZswapInput`
+
+This is a native circuit.
 
 Notifies the context to create a new Zswap input originating from this call.
 Should typically not be called manually, prefer [`sendShielded`](#sendshielded) and
@@ -915,6 +948,8 @@ circuit createZswapInput(coin: QualifiedShieldedCoinInfo): [];
 ```
 
 ### `createZswapOutput`
+
+This is a native circuit.
 
 Notifies the context to create a new Zswap output originating from this call.
 Should typically not be called manually, prefer [`sendShielded`](#sendshielded) and


### PR DESCRIPTION
## Summary

Resolves #683.

PR #662 added the "This is a native circuit/type" annotation to some entries in `doc/api/CompactStandardLibrary/exports.md`. This PR completes the annotation pass and fixes two miscategorised entries.

Scope was determined by cross-referencing every `declare-native-entry` in `compiler/midnight-natives.ss` and `compiler/zkir-v3-natives.ss` — those files are the source of truth for what the compiler treats as native.

## Changes

**Native circuits now annotated** (verified against `declare-native-entry`):
- Hash/commit builtins: `transientHash`, `transientCommit`, `persistentHash`, `persistentCommit`, `degradeToTransient`, `upgradeFromTransient`, `keccak256`
- Elliptic curve operations: `ecAdd`, `ecNeg`, `ecMul`, `ecMulGenerator`, `hashToCurve`
- Field arithmetic: `neg`, `inv`
- Native witnesses: `ownPublicKey`, `createZswapInput`, `createZswapOutput`

(Note: `jubjubPointX`, `jubjubPointY`, `constructJubjubPoint`, and the native types `JubjubPoint`, `JubjubScalar`, `Secp256k1Point`, `Secp256k1Base`, `Secp256k1Scalar` were already annotated by #662.)

**Wrong annotations corrected:**
- `secp256k1PointX` — was \"native type\", corrected to \"native circuit\"
- `secp256k1PointY` — same fix

## Out of scope

Library circuits defined in `compiler/standard-library.compact` (e.g. `merkleTreePathRoot`, `nativeToken`, `mintShieldedToken`, `sendShielded`, `unshieldedBalance*`, `blockTime*`, `jubjubSchnorrVerify`) are not native and therefore do not receive the annotation. `serialize`/`deserialize` are `declare-inline-entry`, not native, and are similarly excluded.

## Testing

Documentation-only change, no compilation needed.