### PR TITLE
fix(compact-update): check for compactc binary, not just directory

### DIFF
--- a/tools/compact/src/bin/compact.rs
+++ b/tools/compact/src/bin/compact.rs
@@ -177,7 +177,7 @@ async fn update(cfg: &CommandLineArguments, command: &UpdateCommand) -> Result<(
             .join(version.to_string())
             .join(cfg.target.to_string());
 
-        if dir.exists() {
+        if dir.join("compactc").is_file() {
             let compiler = Compiler::create(cfg, version.clone(), cfg.target).await?;
 
             println!(

--- a/tools/compact/tests/test_update.rs
+++ b/tools/compact/tests/test_update.rs
@@ -18,6 +18,7 @@ use crate::common::{
 };
 use std::collections::HashMap;
 use std::env;
+use std::fs;
 
 mod common;
 
@@ -103,6 +104,39 @@ fn test_compact_update_invalid_param_unzip() {
 fn test_compact_update_invalid_old_version() {
     let temp_dir = tempfile::tempdir().unwrap();
     let temp_path = temp_dir.path();
+
+    run_command(
+        &[
+            "--directory",
+            &format!("{}", temp_path.display()),
+            "update",
+            "0.19.0",
+        ],
+        None,
+        None,
+        Some("./output/update/err_old_version.txt"),
+        &[],
+        Some(1),
+    );
+}
+
+// Regression test for #739: a leftover version directory from an interrupted install must
+// not be treated as "already installed". Pre-populates the target directory with a placeholder
+// file (as an interrupted extraction would) but without the `compactc` binary. With the bug,
+// `dir.exists()` short-circuits to "already installed" (exit 0). With the fix, the check falls
+// through to `resolve_version`, which reports the same "Couldn't find version 0.19.0" error as
+// `test_compact_update_invalid_old_version` above.
+#[test]
+fn test_compact_update_partial_install_not_treated_as_installed() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path();
+
+    let partial_dir = temp_path
+        .join("versions")
+        .join("0.19.0")
+        .join(get_version());
+    fs::create_dir_all(&partial_dir).unwrap();
+    fs::write(partial_dir.join("artifact.zip"), b"").unwrap();
 
     run_command(
         &[


### PR DESCRIPTION
## Problem

`compact update <version>` performs a quick local check before hitting the network:

```rust
if dir.exists() {
    // treat as already installed, return early
}
```

If a previous install was **interrupted** after the version directory was created but before extraction finished, `dir.exists()` returns `true` — but the `compactc` binary is missing. The tool then silently reports "already installed" and exits without downloading, leaving the toolchain in a broken state.

Issue #739 walks through the concrete reproducer: a fresh Ubuntu 24.04 WSL install lacks `unzip`, `compact update 0.31.1` fails during extraction leaving a directory containing only `artifact.zip`, and the next retry (even after `apt install unzip`) short-circuits with "already installed" and then dies downstream with the misleading `Expecting a file: ".../compactc"` error.

Fixes #739.

## Fix

Check for the binary itself instead of the directory:

```rust
if dir.join("compactc").is_file() {
```

This is the condition that actually matters: the binary is present and usable. A directory without the binary triggers the normal download-and-extract path.

This also makes the early-out consistent with the main install path below (`compact.rs:223`), which already gates on `compiler.path_compactc().is_file()` — same predicate, resolved to the same absolute path via `Compiler::create`.

## Test

Adds `test_compact_update_partial_install_not_treated_as_installed` in `tools/compact/tests/test_update.rs`. It:

1. Creates a temp `--directory` with `versions/0.19.0/<target>/artifact.zip` pre-populated (no `compactc`) — mirroring the partial-install state
2. Runs `compact update 0.19.0`
3. Asserts the output matches the existing `err_old_version.txt` golden file (i.e. control reached `resolve_version`, which then rejects `0.19.0` as too old)

Verified locally:

- [x] Test **passes** with the fix applied
- [x] Test **fails** with the fix reverted (`dir.exists()` restored) — output becomes `compact: <target> -- 0.19.0 -- already installed` followed by the exact misleading `Expecting a file: ".../compactc"` error the issue calls out, confirming both the bug and the reproducer
- [x] Uses the pre-existing `err_old_version.txt` fixture — no new golden file needed
- [x] Does not require `unzip` (invalid version bails before extraction), so unlike some existing update tests it's environment-independent