### PR TITLE
Fix `compact update` leaving a broken installation that reports success

### DIFF
--- a/.github/workflows/compact-test.yml
+++ b/.github/workflows/compact-test.yml
@@ -45,7 +45,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('tools/compact/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
 
@@ -90,15 +90,15 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('tools/compact/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
 
       - name: Cache target directory
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: tools/compact/target
-          key: ${{ runner.os }}-target-${{ hashFiles('tools/compact/Cargo.lock') }}
+          path: target
+          key: ${{ runner.os }}-target-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-target-
 

--- a/.github/workflows/compact-test.yml
+++ b/.github/workflows/compact-test.yml
@@ -55,6 +55,37 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+  # `rust-toolchain.toml' pins the MSRV, and cargo honours it whatever the
+  # runner installed -- so the checks above are pinned too, and lints added by
+  # later stable releases would go unseen until the pin moves. This job is the
+  # usual way to keep that signal: it reports, it does not gate. RUSTUP_TOOLCHAIN
+  # takes precedence over the toolchain file, which is what overrides the pin.
+  lint-on-stable:
+    name: Lint on stable (advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    env:
+      RUSTUP_TOOLCHAIN: stable
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable (branch)
+
+      - name: Install Rust components
+        run: rustup component add clippy --toolchain stable
+
+      - name: Report the toolchain in use
+        run: |
+          rustc --version
+          cargo clippy --version
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
   # Main test matrix
   test:
     name: Test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,11 @@ The Compact project has several components with different tooling requirements:
 Nix is the primary build system for the compiler and runtime. It manages all dependencies (Chez Scheme, Node.js, TypeScript, etc.) automatically via development shells, so you don't need to install them separately.
 
 For the CLI tool, you only need a Rust toolchain -- Nix is not required.
+The exact version is pinned in `rust-toolchain.toml`, and `rustup` installs
+and selects it automatically inside the repository, so a newer default
+toolchain on your machine will not be used. The pin tracks the `rust-version`
+declared in the workspace `Cargo.toml`; it exists so that `cargo clippy`
+reports the same lints locally and in CI.
 
 ## Getting Started
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,8 @@ For the CLI tool, you only need a Rust toolchain -- Nix is not required.
 The exact version is pinned in `rust-toolchain.toml`, and `rustup` installs
 and selects it automatically inside the repository, so a newer default
 toolchain on your machine will not be used. The pin tracks the `rust-version`
-declared in the workspace `Cargo.toml`; it exists so that `cargo clippy`
-reports the same lints locally and in CI.
+declared in the workspace `Cargo.toml`; it exists so that `cargo clippy` and
+cargo's feature resolution behave the same locally and in CI.
 
 ## Getting Started
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,6 +367,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "wiremock",
+ "zip",
 ]
 
 [[package]]
@@ -477,6 +487,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1987,7 +2008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2988,6 +3009,19 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,7 +348,6 @@ dependencies = [
  "ignore",
  "indicatif",
  "octocrab",
- "pretty_assertions",
  "regex",
  "reqwest",
  "semver",
@@ -491,12 +490,6 @@ dependencies = [
  "thiserror 1.0.69",
  "zeroize",
 ]
-
-[[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "dirs"
@@ -1394,16 +1387,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "pretty_assertions"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
-dependencies = [
- "diff",
- "yansi",
 ]
 
 [[package]]
@@ -2968,12 +2951,6 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,32 +3,10 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
 
 [[package]]
 name = "aho-corasick"
@@ -38,12 +16,6 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -142,17 +114,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-scoped"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4042078ea593edffc452eef14e99fdb2b120caa4ad9618bcdeabc4a023b98740"
-dependencies = [
- "futures",
- "pin-project",
- "tokio",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,17 +129,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "atomicwrites"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef1bb8d1b645fe38d51dfc331d720fb5fc2c94b440c76cc79c80ff265ca33e3"
-dependencies = [
- "rustix 0.38.44",
- "tempfile",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "autocfg"
@@ -247,68 +197,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "backtrace-ext"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
-dependencies = [
- "backtrace",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "borsh"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
-dependencies = [
- "bytes",
- "cfg_aliases",
-]
 
 [[package]]
 name = "bstr"
@@ -333,12 +231,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,96 +252,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "camino-tempfile"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64308c4c82a5c38679945ddf88738dc1483dcc563bbb5780755ae9f8497d2b20"
-dependencies = [
- "camino",
- "tempfile",
-]
-
-[[package]]
-name = "cargo-nextest"
-version = "0.9.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74964d5437992aae841ca0dad95ae2ca99c84c11b8c66a51ae142f69948510b2"
-dependencies = [
- "camino",
- "cfg-if",
- "clap",
- "color-eyre",
- "dialoguer 0.12.0",
- "duct",
- "enable-ansi-support",
- "guppy",
- "humantime",
- "idna_adapter",
- "indent_write",
- "itertools",
- "miette",
- "nextest-filtering",
- "nextest-metadata",
- "nextest-runner",
- "nextest-workspace-hack",
- "owo-colors",
- "pathdiff",
- "quick-junit",
- "semver",
- "serde_json",
- "shell-words",
- "supports-color",
- "supports-unicode",
- "swrite",
- "thiserror 2.0.18",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
-]
-
-[[package]]
-name = "cfg-expr"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368"
-dependencies = [
- "smallvec",
- "target-lexicon",
 ]
 
 [[package]]
@@ -498,9 +307,6 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
- "terminal_size",
- "unicase",
- "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -509,10 +315,8 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
- "anstyle",
  "heck",
  "proc-macro2",
- "pulldown-cmark",
  "quote",
  "syn",
 ]
@@ -522,33 +326,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "color-eyre"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
-dependencies = [
- "backtrace",
- "color-spantrace",
- "eyre",
- "indenter",
- "once_cell",
- "owo-colors",
- "tracing-error",
-]
-
-[[package]]
-name = "color-spantrace"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
-dependencies = [
- "once_cell",
- "owo-colors",
- "tracing-core",
- "tracing-error",
-]
 
 [[package]]
 name = "colorchoice"
@@ -563,14 +340,13 @@ dependencies = [
  "anyhow",
  "axoupdater",
  "bytes",
- "cargo-nextest",
  "clap",
  "console 0.16.3",
- "dialoguer 0.11.0",
+ "dialoguer",
  "dirs",
  "futures",
  "ignore",
- "indicatif 0.18.4",
+ "indicatif",
  "octocrab",
  "pretty_assertions",
  "regex",
@@ -602,21 +378,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
-name = "config"
-version = "0.15.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68cfe19cd7d23ffde002c24ffa5cda73931913ef394d5eaaa32037dc940c0c"
-dependencies = [
- "indexmap",
- "pathdiff",
- "ron",
- "serde_core",
- "serde_json",
- "toml 1.1.0+spec-1.1.0",
- "winnow 1.0.0",
-]
-
-[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,21 +403,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "convert_case"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,15 +417,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "crc32fast"
@@ -716,71 +453,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crossterm"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "derive_more",
- "document-features",
- "futures-core",
- "mio",
- "parking_lot",
- "rustix 1.1.4",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,61 +471,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
-name = "debug-ignore"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe7ed1d93f4553003e20b629abe9085e1e81b1429520f897f8f8860bc6dfc21"
-
-[[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
-]
-
-[[package]]
-name = "derive-where"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_more"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn",
 ]
 
 [[package]]
@@ -870,32 +493,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dialoguer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
-dependencies = [
- "console 0.16.3",
- "shell-words",
- "tempfile",
- "zeroize",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
 
 [[package]]
 name = "dirs"
@@ -919,96 +520,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
-]
-
-[[package]]
-name = "dof"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed9b77e3c2a83995eedff2fbf992eef44c9f319b8016254f68108e27a4d06e7"
-dependencies = [
- "goblin",
- "pretty-hex",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "zerocopy",
-]
-
-[[package]]
-name = "dtrace-parser"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc09b90bda5770641457f1c0a42c8203c48f5a3d9799dcf1bafbd84e30ccf080"
-dependencies = [
- "pest",
- "pest_derive",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "duct"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e66e9c0c03d094e1a0ba1be130b849034aa80c3a2ab8ee94316bc809f3fa684"
-dependencies = [
- "libc",
- "os_pipe",
- "shared_child",
- "shared_thread",
-]
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "serde",
- "sha2",
- "signature",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "enable-ansi-support"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea7457668b3da8a4b702f3d79e131aa3e81cd7e81cc95fb2d54fce9f182ecc77"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "encode_unicode"
@@ -1033,49 +548,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
-name = "filetime"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1100,45 +582,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "future-queue"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47cdf4a7eef4808ffa1e5c47dbf37124dfe33a7acc34e8568c5d5359b365a8cb"
-dependencies = [
- "debug-ignore",
- "fnv",
- "futures-util",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -1230,16 +679,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,12 +719,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,50 +730,6 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
-
-[[package]]
-name = "goblin"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983a6aafb3b12d4c41ea78d39e189af4298ce747353945ff5105b54a056e5cd9"
-dependencies = [
- "log",
- "plain",
- "scroll",
-]
-
-[[package]]
-name = "guppy"
-version = "0.17.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a502977572076a42d585dd12f04bccf9c9cafdd4546e99878c072460b904e115"
-dependencies = [
- "ahash",
- "camino",
- "cargo_metadata",
- "cfg-if",
- "debug-ignore",
- "fixedbitset",
- "guppy-workspace-hack",
- "indexmap",
- "itertools",
- "nested",
- "once_cell",
- "pathdiff",
- "petgraph",
- "semver",
- "serde",
- "serde_json",
- "smallvec",
- "static_assertions",
- "target-spec",
-]
-
-[[package]]
-name = "guppy-workspace-hack"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92620684d99f750bae383ecb3be3748142d6095760afd5cbcf2261e9a279d780"
 
 [[package]]
 name = "h2"
@@ -1367,7 +756,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash 0.1.5",
+ "foldhash",
 ]
 
 [[package]]
@@ -1375,9 +764,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
-]
 
 [[package]]
 name = "heck"
@@ -1390,21 +776,6 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "homedir"
@@ -1464,22 +835,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humantime"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
-
-[[package]]
-name = "humantime-serde"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
-dependencies = [
- "humantime",
- "serde",
-]
-
-[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,22 +886,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -1604,19 +943,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
-name = "iddqd"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b215e67ed1d1a4b1702acd787c487d16e4c977c5dcbcc4587bdb5ea26b6ce06"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
- "hashbrown 0.16.1",
- "rustc-hash",
-]
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1662,18 +988,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indent_write"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cfe9645a18782869361d9c8732246be7b410ad4e919d3609ebabdac00ba12c3"
-
-[[package]]
-name = "indenter"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
-
-[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,19 +997,6 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "indicatif"
-version = "0.17.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
-dependencies = [
- "console 0.15.11",
- "number_prefix",
- "portable-atomic",
- "unicode-width 0.2.2",
- "web-time",
 ]
 
 [[package]]
@@ -1728,41 +1029,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_ci"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -1813,29 +1089,14 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
- "bitflags",
  "libc",
- "plain",
- "redox_syscall 0.7.3",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -1865,30 +1126,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "memmap2"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "miette"
 version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
 dependencies = [
- "backtrace",
- "backtrace-ext",
  "cfg-if",
  "miette-derive",
- "owo-colors",
- "supports-color",
- "supports-hyperlinks",
- "supports-unicode",
- "terminal_size",
- "textwrap",
  "unicode-width 0.1.14",
 ]
 
@@ -1926,7 +1170,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1940,171 +1183,6 @@ dependencies = [
  "num-traits",
  "pxfm",
 ]
-
-[[package]]
-name = "mukti-metadata"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fa66de8d0e39780ff7cbb1409149f8423418339230f520240e5eb08576e1e8"
-dependencies = [
- "semver",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
-name = "nested"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b420f638f07fe83056b55ea190bb815f609ec5a35e7017884a10f78839c9e"
-
-[[package]]
-name = "newtype-uuid"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c012d14ef788ab066a347d19e3dda699916c92293b05b85ba2c76b8c82d2830"
-dependencies = [
- "serde",
- "uuid",
-]
-
-[[package]]
-name = "nextest-filtering"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b85e1a882a9edce41978737f2d4bfeeec671feda7e370d03dbf6c19e6493570"
-dependencies = [
- "globset",
- "guppy",
- "miette",
- "nextest-metadata",
- "nextest-workspace-hack",
- "recursion",
- "regex",
- "regex-syntax",
- "smol_str",
- "thiserror 2.0.18",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "nextest-metadata"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2725d07ba30cabadad8e4219185a5a14dbc478e32ea72af4eb89d63f9705ca7f"
-dependencies = [
- "camino",
- "nextest-workspace-hack",
- "serde",
- "serde_json",
- "smol_str",
- "target-spec",
-]
-
-[[package]]
-name = "nextest-runner"
-version = "0.96.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8418a0f21725c9fb2265a3c6cbafc6e80b4ee59e014c4d191b65ab6f0b23b5ce"
-dependencies = [
- "aho-corasick",
- "async-scoped",
- "atomicwrites",
- "bstr",
- "bytes",
- "camino",
- "camino-tempfile",
- "cargo_metadata",
- "cfg-if",
- "chrono",
- "config",
- "console 0.16.3",
- "crossterm",
- "debug-ignore",
- "derive-where",
- "duct",
- "dunce",
- "future-queue",
- "futures",
- "guppy",
- "hex",
- "home",
- "http",
- "humantime-serde",
- "iddqd",
- "indent_write",
- "indexmap",
- "indicatif 0.18.4",
- "is_ci",
- "itertools",
- "libc",
- "miette",
- "mukti-metadata",
- "newtype-uuid",
- "nextest-filtering",
- "nextest-metadata",
- "nextest-workspace-hack",
- "nix",
- "owo-colors",
- "pin-project-lite",
- "quick-junit",
- "rand",
- "regex",
- "self_update",
- "semver",
- "serde",
- "serde_ignored",
- "serde_json",
- "serde_path_to_error",
- "sha2",
- "shell-words",
- "smallvec",
- "smol_str",
- "strip-ansi-escapes",
- "supports-unicode",
- "swrite",
- "tar",
- "target-spec",
- "target-spec-miette",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "toml 0.8.23",
- "toml_edit 0.23.10+spec-1.0.0",
- "tracing",
- "unicode-ident",
- "unicode-normalization",
- "unicode-width 0.2.2",
- "usdt",
- "win32job",
- "windows-sys 0.61.2",
- "xxhash-rust",
- "zstd",
-]
-
-[[package]]
-name = "nextest-workspace-hack"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d906846a98739ed9d73d66e62c2641eef8321f1734b7a1156ab045a0248fb2b3"
 
 [[package]]
 name = "nix"
@@ -2163,21 +1241,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "octocrab"
 version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,70 +1293,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "openssl-sys"
-version = "0.9.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "os_pipe"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "owo-colors"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking_lot"
@@ -2313,18 +1322,9 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-dependencies = [
- "camino",
 ]
 
 [[package]]
@@ -2342,60 +1342,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pest"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
-dependencies = [
- "pest",
- "sha2",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
-dependencies = [
- "fixedbitset",
- "hashbrown 0.15.5",
- "indexmap",
-]
 
 [[package]]
 name = "pin-project"
@@ -2430,28 +1376,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,12 +1395,6 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
-
-[[package]]
-name = "pretty-hex"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a65843dfefbafd3c879c683306959a6de478443ffe9c9adf02f5976432402d7"
 
 [[package]]
 name = "pretty_assertions"
@@ -2508,54 +1426,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulldown-cmark"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
-dependencies = [
- "bitflags",
- "memchr",
- "unicase",
-]
-
-[[package]]
 name = "pxfm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
-
-[[package]]
-name = "quick-junit"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee9342d671fae8d66b3ae9fd7a9714dfd089c04d2a8b1ec0436ef77aee15e5f"
-dependencies = [
- "chrono",
- "indexmap",
- "newtype-uuid",
- "quick-xml 0.38.4",
- "strip-ansi-escapes",
- "thiserror 2.0.18",
- "uuid",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.37.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "quinn"
@@ -2640,7 +1514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -2650,16 +1524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
+ "rand_core",
 ]
 
 [[package]]
@@ -2672,25 +1537,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "recursion"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dba2197bf7b1d87b4dd460c195f4edeb45a94e82e8054f8d5f317c1f0e93ca1"
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags",
 ]
@@ -2743,20 +1593,16 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2767,7 +1613,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -2796,53 +1641,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ron"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd490c5b18261893f14449cbd28cb9c0b637aebf161cd77900bfdedaff21ec32"
-dependencies = [
- "bitflags",
- "indexmap",
- "once_cell",
- "serde",
- "serde_derive",
- "typeid",
- "unicode-ident",
-]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "rustix"
@@ -2853,7 +1655,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -2942,26 +1744,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scroll"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1257cd4248b4132760d6524d6dda4e053bc648c9070b960929bf50cfb1e7add"
-dependencies = [
- "scroll_derive",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed76efe62313ab6610570951494bdaa81568026e0318eaa55f167de70eeea67d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "secrecy"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3005,29 +1787,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "self_update"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d832c086ece0dacc29fb2947bb4219b8f6e12fe9e40b7108f9e57c4224e47b5c"
-dependencies = [
- "either",
- "flate2",
- "hyper",
- "indicatif 0.17.11",
- "log",
- "quick-xml 0.37.5",
- "regex",
- "reqwest",
- "self-replace",
- "semver",
- "serde_json",
- "tar",
- "tempfile",
- "urlencoding",
- "zipsign-api",
-]
-
-[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3068,22 +1827,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_ignored"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -3103,36 +1851,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "serde_tokenstream"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c49585c52c01f13c5c2ebb333f14f6885d76daa768d8a037d28017ec538c69"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "syn",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3143,43 +1861,6 @@ dependencies = [
  "ryu",
  "serde",
 ]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
-name = "shared_child"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
-dependencies = [
- "libc",
- "sigchld",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "shared_thread"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b86057fcb5423f5018e331ac04623e32d6b5ce85e33300f92c79a1973928b0"
 
 [[package]]
 name = "shell-words"
@@ -3194,38 +1875,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "sigchld"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
-dependencies = [
- "libc",
- "os_pipe",
- "signal-hook",
-]
-
-[[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3233,16 +1882,6 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
-]
-
-[[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3282,16 +1921,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "smol_str"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
-dependencies = [
- "borsh",
- "serde",
-]
-
-[[package]]
 name = "snafu"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3323,31 +1952,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strip-ansi-escapes"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
-dependencies = [
- "vte",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3358,33 +1962,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "supports-color"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
-dependencies = [
- "is_ci",
-]
-
-[[package]]
-name = "supports-hyperlinks"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
-
-[[package]]
-name = "supports-unicode"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
-
-[[package]]
-name = "swrite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3fece30b2dc06d65ecbca97b602db15bf75f932711d60cc604534f1f8b7a03"
 
 [[package]]
 name = "syn"
@@ -3407,47 +1984,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tar"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
-name = "target-lexicon"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
-
-[[package]]
-name = "target-spec"
-version = "3.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c173ce474b6257cfb2a107949e48eb1ab9cae21cecbdf13401ae3be4a411a"
-dependencies = [
- "cfg-expr",
- "guppy-workspace-hack",
- "serde",
- "serde_json",
- "target-lexicon",
-]
-
-[[package]]
-name = "target-spec-miette"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e23aa20579815570223b4c5bc150e95fcb362545e6eaf46a57d2a2bbcffd47b5"
-dependencies = [
- "guppy-workspace-hack",
- "miette",
- "target-spec",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3456,28 +1992,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
-dependencies = [
- "rustix 1.1.4",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
-dependencies = [
- "unicode-linebreak",
- "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -3518,25 +2034,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "thread-id"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2010d27add3f3240c1fef7959f46c814487b216baee662af53be645ba7831c07"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -3614,33 +2111,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
-dependencies = [
- "futures-core",
- "pin-project-lite",
  "tokio",
 ]
 
@@ -3656,110 +2132,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
-
-[[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
-version = "1.1.0+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned 1.1.0",
- "toml_datetime 1.1.0+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 1.0.0",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned 1.1.0",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
-dependencies = [
- "winnow 1.0.0",
-]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
-name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
 name = "tower"
@@ -3844,40 +2216,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-error"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
-dependencies = [
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
-dependencies = [
- "sharded-slab",
- "thread_local",
- "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -3887,55 +2225,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typeid"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
-
-[[package]]
-name = "typenum"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-linebreak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da36089a805484bcccfffe0739803392c8298778a2d2f09febf76fac5ad9025b"
 
 [[package]]
 name = "unicode-width"
@@ -3981,74 +2274,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
-name = "usdt"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1953f8d8a98ac7883c230963291acb65c7ed6ae3e2e4c99d5c65f4e65cc9db38"
-dependencies = [
- "dof",
- "goblin",
- "memmap2",
- "serde",
- "usdt-attr-macro",
- "usdt-impl",
- "usdt-macro",
-]
-
-[[package]]
-name = "usdt-attr-macro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d0d673848744c556fcfe8479f87b6974459106e4c41f38375f6d559bb0ee28"
-dependencies = [
- "dtrace-parser",
- "proc-macro2",
- "quote",
- "serde_tokenstream",
- "syn",
- "usdt-impl",
-]
-
-[[package]]
-name = "usdt-impl"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf0085a93af1ca095d8b1dc8672cc4620fcd1db5dff8d165486067badce05555"
-dependencies = [
- "byteorder",
- "dof",
- "dtrace-parser",
- "libc",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "syn",
- "thiserror 2.0.18",
- "thread-id",
-]
-
-[[package]]
-name = "usdt-macro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9bf594f86b676f7e2fd3d523d50f9d0cffecff6c19729ff5dbebe86c4cb8cb2"
-dependencies = [
- "dtrace-parser",
- "proc-macro2",
- "quote",
- "serde_tokenstream",
- "syn",
- "usdt-impl",
-]
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4059,45 +2284,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uuid"
-version = "1.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
-dependencies = [
- "getrandom 0.4.2",
- "js-sys",
- "serde_core",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "vte"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "walkdir"
@@ -4285,32 +2471,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
-name = "win32job"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6a6724ccfbf34154a8691bd868b0fcd2be2ca3f7b47b32614654f1a01b191c"
-dependencies = [
- "thiserror 1.0.69",
- "windows",
-]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4318,12 +2478,6 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
@@ -4705,24 +2859,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "wiremock"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4834,22 +2970,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "xattr"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-dependencies = [
- "libc",
- "rustix 1.1.4",
-]
-
-[[package]]
-name = "xxhash-rust"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
-
-[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4882,46 +3002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
-name = "zipsign-api"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0"
-dependencies = [
- "base64",
- "ed25519-dalek",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -1977,6 +1978,16 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,30 @@
+# This file is part of Compact.
+# Copyright (C) 2026 contributors to Minokawa Compact
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Pin the toolchain used to build, lint and test the `compact' CLI.
+#
+# Without a pin, `cargo clippy -- -D warnings' passes or fails depending on
+# whichever release happens to be current: clippy moves lints between
+# `style' (warn by default) and `pedantic' (allow by default) between
+# versions, so the same commit can be clean on one machine and fail on
+# another. `compact-test.yml' installs `stable', which makes CI's result a
+# function of the calendar rather than of the code.
+#
+# The pin is the MSRV declared as `rust-version' in the workspace Cargo.toml,
+# so the toolchain everyone builds with is also the oldest one this crate
+# claims to support. Raise both together.
+[toolchain]
+channel = "1.88.0"
+components = ["clippy", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,8 +1,8 @@
 # This file is part of Compact.
-# Copyright (C) 2026 contributors to Minokawa Compact
+# Copyright (C) 2026 Midnight Foundation
 # SPDX-License-Identifier: Apache-2.0
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #	http://www.apache.org/licenses/LICENSE-2.0

--- a/tools/compact/CHANGELOG.md
+++ b/tools/compact/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The toolchain archive is now unpacked by `compact` itself rather than by
+  running `unzip`. `unzip` is not installed by default on many systems -- the
+  machine in issue #739 had `curl`, `tar`, `xz`, `zstd` and `gzip` but not
+  `unzip`, so the toolchain could not be installed at all until a package was
+  added. There is no longer an external program to install.
+
 - `--help` output now wraps to the width of the terminal in the installed
   binary, not only under `cargo test`. `clap`'s `wrap_help` feature was
   never requested by this crate: it arrived through Cargo feature

--- a/tools/compact/CHANGELOG.md
+++ b/tools/compact/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `unzip`, so the toolchain could not be installed at all until a package was
   added. There is no longer an external program to install.
 
+- An archive that cannot be unpacked is now discarded and fetched again. The
+  archive was only downloaded when it was not already on disk, so a complete
+  but unreadable one -- a bad checksum, a resume stitched across a changed
+  artifact -- failed every retry identically, with deleting it by hand the only
+  way forward. Only the archive's own faults are retried: a full disk or a
+  permission error is reported as it happens, since fetching the file again
+  would not help.
+
 - `--help` output now wraps to the width of the terminal in the installed
   binary, not only under `cargo test`. `clap`'s `wrap_help` feature was
   never requested by this crate: it arrived through Cargo feature

--- a/tools/compact/CHANGELOG.md
+++ b/tools/compact/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `--help` output now wraps to the width of the terminal in the installed
+  binary, not only under `cargo test`. `clap`'s `wrap_help` feature was
+  never requested by this crate: it arrived through Cargo feature
+  unification with the `cargo-nextest` dev-dependency, so wrapped help
+  appeared in test builds while the binary users install printed one long
+  line. The expected-output files recorded the wrapped form, so the help
+  tests asserted output no user had ever seen. The feature is now
+  requested explicitly.
+
 ### Fixed
 
 - `compact update <version>` no longer treats a version as installed when only

--- a/tools/compact/CHANGELOG.md
+++ b/tools/compact/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `compact update <version>` no longer treats a version as installed when only
+  the version directory is present. An extraction that fails leaves that
+  directory behind holding nothing but `artifact.zip`, and the previous check
+  looked no further: it reported "already installed", skipped re-extraction, and
+  then failed with `Expecting a file: '.../compactc'`. Installing the missing
+  dependency and re-running now repairs the installation rather than reporting
+  the same error again.
+
+  Because the default-compiler symlink was written before it was validated, a
+  failed retry also left a dangling `~/.compact/bin/compactc`, which made every
+  later `compact check`, `compact list --installed` and `compact compile` fail
+  the same way. `compact` now refuses to link a compiler binary that is not
+  there, so one incomplete install can no longer break the others.
+
+  Fixes issue #739.
+
+- The error raised when the archive extraction command is missing now names it.
+  A machine without `unzip` previously reported only `Failed to spawn artifact
+  extraction command` followed by `No such file or directory (os error 2)`,
+  identifying neither the command that was missing nor what to do about it.
+
+- Archive extraction now passes `-o`. Standard input is closed for the
+  extraction command, so an archive left partially extracted by an interrupted
+  run produced an overwrite prompt that failed the retry instead of repairing
+  it.
+
 ## [Compact tools 0.5.2]
 
 ### Fixed

--- a/tools/compact/Cargo.toml
+++ b/tools/compact/Cargo.toml
@@ -38,7 +38,6 @@ futures = "0.3.31"
 ignore = "0.4.23"
 indicatif = "0.18.0"
 octocrab = "0.44.1"
-pretty_assertions = "1.4.1"
 regex = "1.11.1"
 reqwest = { version = "0.12.9", default-features = false, features = [
   "gzip",
@@ -53,7 +52,6 @@ similar = "2.7.0"
 tokio = { version = "1.42.0", features = ["full", "macros"] }
 
 [dev-dependencies]
-pretty_assertions = "1.4.1"
 tempfile = "3.20.0"
 wiremock = "0.6.4"
 

--- a/tools/compact/Cargo.toml
+++ b/tools/compact/Cargo.toml
@@ -30,7 +30,7 @@ axoupdater = { version = "0.9.0", default-features = false, features = [
   "github_releases",
 ] }
 bytes = "1.11.1"
-clap = { version = "4.5.23", features = ["derive", "env"] }
+clap = { version = "4.5.23", features = ["derive", "env", "wrap_help"] }
 console = "0.16.0"
 dialoguer = "0.11.0"
 dirs = "5.0.1"

--- a/tools/compact/Cargo.toml
+++ b/tools/compact/Cargo.toml
@@ -50,6 +50,9 @@ serde = { version = "1.0.216", features = ["derive"] }
 serde_json = "1.0.133"
 similar = "2.7.0"
 tokio = { version = "1.42.0", features = ["full", "macros"] }
+# Read-only deflate: the launcher never writes an archive, so this avoids the
+# compressor and the second inflate backend that the `deflate' feature pulls in.
+zip = { version = "4", default-features = false, features = ["deflate-flate2"] }
 
 [dev-dependencies]
 tempfile = "3.20.0"

--- a/tools/compact/Cargo.toml
+++ b/tools/compact/Cargo.toml
@@ -53,7 +53,6 @@ similar = "2.7.0"
 tokio = { version = "1.42.0", features = ["full", "macros"] }
 
 [dev-dependencies]
-cargo-nextest = "0.9.97"
 pretty_assertions = "1.4.1"
 tempfile = "3.20.0"
 wiremock = "0.6.4"

--- a/tools/compact/output/check/std_check_help_short.txt
+++ b/tools/compact/output/check/std_check_help_short.txt
@@ -3,7 +3,6 @@ Check for updates with the remote server
 Usage: compact check [OPTIONS]
 
 Options:
-      --directory <DIRECTORY>  Set the compact artifact directory [env: COMPACT_DIRECTORY=]
-                               [default: [USER_DIR]/.compact]
+      --directory <DIRECTORY>  Set the compact artifact directory [env: COMPACT_DIRECTORY=] [default: [USER_DIR]/.compact]
   -h, --help                   Print help (see more with '--help')
   -V, --version                Print version

--- a/tools/compact/output/clean/std_clean_help_short.txt
+++ b/tools/compact/output/clean/std_clean_help_short.txt
@@ -5,7 +5,6 @@ Usage: compact clean [OPTIONS]
 Options:
   -k, --keep-current           Keep the version currently in use
       --cache                  Also remove the cache directory
-      --directory <DIRECTORY>  Set the compact artifact directory [env: COMPACT_DIRECTORY=]
-                               [default: [USER_DIR]/.compact]
+      --directory <DIRECTORY>  Set the compact artifact directory [env: COMPACT_DIRECTORY=] [default: [USER_DIR]/.compact]
   -h, --help                   Print help (see more with '--help')
   -V, --version                Print version

--- a/tools/compact/output/fixup/std_fixup_help_short.txt
+++ b/tools/compact/output/fixup/std_fixup_help_short.txt
@@ -7,8 +7,7 @@ Arguments:
 
 Options:
   -c, --check                  Check if inputs need fixup without changing them
-      --directory <DIRECTORY>  Set the compact artifact directory [env: COMPACT_DIRECTORY=]
-                               [default: [COMPACT_DIR]]
+      --directory <DIRECTORY>  Set the compact artifact directory [env: COMPACT_DIRECTORY=] [default: [COMPACT_DIR]]
       --update-Uint-ranges     Adjust Uint range endpoints
       --vscode                 Format error messages as single line (for VS Code extension)
   -v, --verbose                Print verbose output

--- a/tools/compact/output/format/std_format_help_short.txt
+++ b/tools/compact/output/format/std_format_help_short.txt
@@ -7,8 +7,7 @@ Arguments:
 
 Options:
   -c, --check                  Check if inputs are formatted without changing them
-      --directory <DIRECTORY>  Set the compact artifact directory [env: COMPACT_DIRECTORY=]
-                               [default: [USER_DIR]/.compact]
+      --directory <DIRECTORY>  Set the compact artifact directory [env: COMPACT_DIRECTORY=] [default: [USER_DIR]/.compact]
   -v, --verbose                Print each file seen by the formatter
   -V, --version                Print the toolchain version
       --language-version       Print the language version

--- a/tools/compact/output/help/std_short.txt
+++ b/tools/compact/output/help/std_short.txt
@@ -14,7 +14,6 @@ Commands:
   help     Print this message or the help of the given subcommand(s)
 
 Options:
-      --directory <DIRECTORY>  Set the compact artifact directory [env: COMPACT_DIRECTORY=]
-                               [default: [USER_DIR]/.compact]
+      --directory <DIRECTORY>  Set the compact artifact directory [env: COMPACT_DIRECTORY=] [default: [USER_DIR]/.compact]
   -h, --help                   Print help (see more with '--help')
   -V, --version                Print version

--- a/tools/compact/output/list/err_dangling_default.txt
+++ b/tools/compact/output/list/err_dangling_default.txt
@@ -1,0 +1,5 @@
+Error: Failed to list available versions
+
+Caused by:
+    0: Failed to get the current compiler
+    1: The default compiler is missing: `"[COMPACT_DIR]/bin/compactc"' points at `"[COMPACT_DIR]/versions/[COMPACTC_VERSION]/[SYSTEM_VERSION]/compactc"', which does not exist. Run `compact update [COMPACTC_VERSION]' to reinstall it.

--- a/tools/compact/output/list/std_list_help_short.txt
+++ b/tools/compact/output/list/std_list_help_short.txt
@@ -4,7 +4,6 @@ Usage: compact list [OPTIONS]
 
 Options:
   -i, --installed              Show installed versions
-      --directory <DIRECTORY>  Set the compact artifact directory [env: COMPACT_DIRECTORY=]
-                               [default: [USER_DIR]/.compact]
+      --directory <DIRECTORY>  Set the compact artifact directory [env: COMPACT_DIRECTORY=] [default: [USER_DIR]/.compact]
   -h, --help                   Print help (see more with '--help')
   -V, --version                Print version

--- a/tools/compact/output/self/std_default.txt
+++ b/tools/compact/output/self/std_default.txt
@@ -8,7 +8,6 @@ Commands:
   help    Print this message or the help of the given subcommand(s)
 
 Options:
-      --directory <DIRECTORY>  Set the compact artifact directory [env: COMPACT_DIRECTORY=]
-                               [default: [USER_DIR]/.compact]
+      --directory <DIRECTORY>  Set the compact artifact directory [env: COMPACT_DIRECTORY=] [default: [USER_DIR]/.compact]
   -h, --help                   Print help (see more with '--help')
   -V, --version                Print version

--- a/tools/compact/output/self/std_default_help_short.txt
+++ b/tools/compact/output/self/std_default_help_short.txt
@@ -8,7 +8,6 @@ Commands:
   help    Print this message or the help of the given subcommand(s)
 
 Options:
-      --directory <DIRECTORY>  Set the compact artifact directory [env: COMPACT_DIRECTORY=]
-                               [default: [USER_DIR]/.compact]
+      --directory <DIRECTORY>  Set the compact artifact directory [env: COMPACT_DIRECTORY=] [default: [USER_DIR]/.compact]
   -h, --help                   Print help (see more with '--help')
   -V, --version                Print version

--- a/tools/compact/output/update/std_default_help_short.txt
+++ b/tools/compact/output/update/std_default_help_short.txt
@@ -7,7 +7,6 @@ Arguments:
 
 Options:
       --no-set-default         Don't make the newly installed compiler the default one
-      --directory <DIRECTORY>  Set the compact artifact directory [env: COMPACT_DIRECTORY=]
-                               [default: [USER_DIR]/.compact]
+      --directory <DIRECTORY>  Set the compact artifact directory [env: COMPACT_DIRECTORY=] [default: [USER_DIR]/.compact]
   -h, --help                   Print help (see more with '--help')
   -V, --version                Print version

--- a/tools/compact/output/update/std_reinstall_incomplete.txt
+++ b/tools/compact/output/update/std_reinstall_incomplete.txt
@@ -1,0 +1,3 @@
+compact: [SYSTEM_VERSION] -- [COMPACTC_VERSION] -- previous installation is incomplete, reinstalling
+compact: [SYSTEM_VERSION] -- [COMPACTC_VERSION] -- installed
+compact: [SYSTEM_VERSION] -- [COMPACTC_VERSION] -- default.

--- a/tools/compact/output/update/std_repair_corrupt_archive.txt
+++ b/tools/compact/output/update/std_repair_corrupt_archive.txt
@@ -1,0 +1,4 @@
+compact: [SYSTEM_VERSION] -- [COMPACTC_VERSION] -- previous installation is incomplete, reinstalling
+compact: [SYSTEM_VERSION] -- [COMPACTC_VERSION] -- downloaded archive is unreadable, downloading it again
+compact: [SYSTEM_VERSION] -- [COMPACTC_VERSION] -- installed
+compact: [SYSTEM_VERSION] -- [COMPACTC_VERSION] -- default.

--- a/tools/compact/src/bin/compact.rs
+++ b/tools/compact/src/bin/compact.rs
@@ -177,7 +177,11 @@ async fn update(cfg: &CommandLineArguments, command: &UpdateCommand) -> Result<(
             .join(version.to_string())
             .join(cfg.target.to_string());
 
-        if dir.exists() {
+        // A version counts as installed only when the compiler binary itself is
+        // there. A previous run whose extraction failed leaves the directory
+        // behind holding nothing but `artifact.zip'; treating that as installed
+        // skips re-extraction and reports success for a broken install.
+        if dir.join("compactc").is_file() {
             let compiler = Compiler::create(cfg, version.clone(), cfg.target).await?;
 
             println!(
@@ -200,6 +204,18 @@ async fn update(cfg: &CommandLineArguments, command: &UpdateCommand) -> Result<(
             }
 
             return Ok(());
+        } else if dir.exists() {
+            // The directory survives a failed extraction. Say so, rather than
+            // silently re-downloading, so the earlier failure is accounted for.
+            println!(
+                "{label}: {target} -- {version} -- {message}",
+                label = cfg.style.label(),
+                target = cfg.style.target(cfg.target),
+                version = cfg.style.version(version.clone()),
+                message = cfg
+                    .style
+                    .warn("previous installation is incomplete, reinstalling"),
+            );
         }
     }
 

--- a/tools/compact/src/bin/compact.rs
+++ b/tools/compact/src/bin/compact.rs
@@ -13,19 +13,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{path::PathBuf, str::FromStr, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::Arc,
+};
 
 use anyhow::{Context as _, Result, anyhow, bail};
 use axoupdater::AxoUpdater;
 use clap::Parser;
 use compact::{
     COMPACT_NAME, COMPACT_VERSION, CleanCommand, Command, CommandLineArguments, CompileCommand,
-    Compiler, FixupCommand, FormatCommand, ListCommand, SSelf, UpdateCommand, VersionSpec,
+    Compiler, CompilerAsset, FixupCommand, FormatCommand, ListCommand, SSelf, UpdateCommand,
+    VersionSpec,
     fetch::{self, MidnightArtifacts},
     file,
     fixup::{self, FixupStatus, fixup_file},
     formatter::{self, FormatStatus, format_file},
-    http, progress,
+    http, is_corrupt_archive, progress,
     utils::{self, set_current_compiler},
 };
 use indicatif::ProgressStyle;
@@ -232,27 +237,13 @@ async fn update(cfg: &CommandLineArguments, command: &UpdateCommand) -> Result<(
     let target = cfg.target;
 
     let compiler = Compiler::create(cfg, version.clone(), target).await?;
-    let zip_file = file::File::new(compiler.path_zip());
 
     let mut installed = false;
 
     if !compiler.path_compactc().is_file() {
         let compiler_asset = artifact.compiler(cfg)?;
 
-        if !zip_file.exist() {
-            let client = http::Client::new()?;
-
-            let download_url = compiler_asset.download_url().clone();
-            let download_future = client.download_to_file(download_url, zip_file);
-
-            let dl = progress::future("Downloading artifact", download_future).await?;
-
-            progress::progress(dl).await?;
-        }
-
-        let install_future = compiler_asset.install();
-
-        progress::future("Unpacking compiler", install_future).await?;
+        download_and_install(cfg, &version, &compiler_asset, &compiler.path_zip()).await?;
 
         installed = true;
     }
@@ -284,6 +275,66 @@ async fn update(cfg: &CommandLineArguments, command: &UpdateCommand) -> Result<(
             message = cfg.style.success("default"),
         );
     }
+
+    Ok(())
+}
+
+/// Fetch the archive unless it is already here, then unpack it.
+///
+/// An archive that cannot be read is discarded and fetched once more. The
+/// archive is otherwise reused whenever it is on disk, so a corrupt one would
+/// fail every retry in exactly the same way and leave deleting it by hand as
+/// the only way forward -- which is the shape of the failure reported in issue
+/// #739. Only the archive's own faults are retried: a full disk or a
+/// permission error is reported as it happens, because fetching the file again
+/// would not help.
+async fn download_and_install(
+    cfg: &CommandLineArguments,
+    version: &semver::Version,
+    compiler_asset: &CompilerAsset,
+    zip_path: &Path,
+) -> Result<()> {
+    if !file::File::new(zip_path.to_path_buf()).exist() {
+        download_archive(compiler_asset, zip_path).await?;
+    }
+
+    let Err(error) = progress::future("Unpacking compiler", compiler_asset.install()).await else {
+        return Ok(());
+    };
+
+    if !is_corrupt_archive(&error) {
+        return Err(error);
+    }
+
+    println!(
+        "{label}: {target} -- {version} -- {message}",
+        label = cfg.style.label(),
+        target = cfg.style.target(cfg.target),
+        version = cfg.style.version(version.clone()),
+        message = cfg
+            .style
+            .warn("downloaded archive is unreadable, downloading it again"),
+    );
+
+    utils::remove_file_if_exists(zip_path)
+        .await
+        .with_context(|| anyhow!("Failed to discard the unreadable archive `{zip_path:?}'"))?;
+
+    download_archive(compiler_asset, zip_path).await?;
+
+    progress::future("Unpacking compiler", compiler_asset.install()).await
+}
+
+async fn download_archive(compiler_asset: &CompilerAsset, zip_path: &Path) -> Result<()> {
+    let client = http::Client::new()?;
+
+    let download_url = compiler_asset.download_url().clone();
+    let download_future =
+        client.download_to_file(download_url, file::File::new(zip_path.to_path_buf()));
+
+    let dl = progress::future("Downloading artifact", download_future).await?;
+
+    progress::progress(dl).await?;
 
     Ok(())
 }

--- a/tools/compact/src/bin/compact.rs
+++ b/tools/compact/src/bin/compact.rs
@@ -250,9 +250,9 @@ async fn update(cfg: &CommandLineArguments, command: &UpdateCommand) -> Result<(
             progress::progress(dl).await?;
         }
 
-        let unzip_future = compiler_asset.unzip();
+        let install_future = compiler_asset.install();
 
-        progress::future("Unpacking compiler", unzip_future).await?;
+        progress::future("Unpacking compiler", install_future).await?;
 
         installed = true;
     }

--- a/tools/compact/src/bin/compact.rs
+++ b/tools/compact/src/bin/compact.rs
@@ -314,7 +314,7 @@ async fn format(cfg: &CommandLineArguments, command: &FormatCommand) -> Result<(
             print!("{}", String::from_utf8_lossy(&output.stdout));
         } else {
             eprint!("{}", String::from_utf8_lossy(&output.stderr));
-            bail!("format-compact {} failed", flag);
+            bail!("format-compact {flag} failed");
         }
         return Ok(());
     }
@@ -421,7 +421,7 @@ async fn fixup(cfg: &CommandLineArguments, command: &FixupCommand) -> Result<()>
             print!("{}", String::from_utf8_lossy(&output.stdout));
         } else {
             eprint!("{}", String::from_utf8_lossy(&output.stderr));
-            bail!("fixup-compact {} failed", flag);
+            bail!("fixup-compact {flag} failed");
         }
         return Ok(());
     }

--- a/tools/compact/src/compiler.rs
+++ b/tools/compact/src/compiler.rs
@@ -122,7 +122,6 @@ impl Compiler {
 
         let mut cmd = Command::new(program);
 
-        // execute the unzip command in the artifact directory
         cmd.current_dir(cwd);
 
         cmd.args(args);

--- a/tools/compact/src/compiler_legacy.rs
+++ b/tools/compact/src/compiler_legacy.rs
@@ -19,6 +19,28 @@ use semver::Version;
 use std::path::{Path, PathBuf};
 use tokio::fs;
 
+/// Marker attached to a failure caused by the archive itself -- unreadable, or
+/// an entry that failed its checksum -- rather than by the machine unpacking
+/// it. A caller discards such an archive and fetches it again; it must not do
+/// that for a full disk or a permission error, which re-downloading cannot fix.
+#[derive(Debug)]
+pub struct CorruptArchive;
+
+impl std::fmt::Display for CorruptArchive {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("the downloaded archive could not be read")
+    }
+}
+
+impl std::error::Error for CorruptArchive {}
+
+/// Whether `error` was caused by the archive rather than by the machine.
+pub fn is_corrupt_archive(error: &anyhow::Error) -> bool {
+    // `downcast_ref' searches the context chain; `chain()' yields anyhow's own
+    // wrappers rather than the attached values, so it would never match.
+    error.downcast_ref::<CorruptArchive>().is_some()
+}
+
 /// The compiler binary, whose presence callers take as proof that a version is
 /// completely installed.
 const COMPILER_BIN: &str = "compactc";
@@ -68,11 +90,15 @@ fn extract_archive(dir: &Path, zip: &Path) -> Result<()> {
     let file = std::fs::File::open(zip).with_context(|| anyhow!("Failed to open `{zip:?}'"))?;
 
     let mut archive = zip::ZipArchive::new(file)
+        .map_err(anyhow::Error::new)
+        .context(CorruptArchive)
         .with_context(|| anyhow!("Failed to read `{zip:?}' as a zip archive"))?;
 
     for index in 0..archive.len() {
         let mut entry = archive
             .by_index(index)
+            .map_err(anyhow::Error::new)
+            .context(CorruptArchive)
             .with_context(|| anyhow!("Failed to read entry {index} of `{zip:?}'"))?;
 
         if entry.is_dir() {
@@ -93,6 +119,18 @@ fn extract_archive(dir: &Path, zip: &Path) -> Result<()> {
             .with_context(|| anyhow!("Failed to create `{target:?}'"))?;
 
         std::io::copy(&mut entry, &mut output)
+            .map_err(|error| {
+                // a bad checksum or a malformed compressed stream is the
+                // archive's fault; a full disk is not
+                let corrupt = error.kind() == std::io::ErrorKind::InvalidData;
+                let error = anyhow::Error::new(error);
+
+                if corrupt {
+                    error.context(CorruptArchive)
+                } else {
+                    error
+                }
+            })
             .with_context(|| anyhow!("Failed to write `{target:?}'"))?;
 
         // `unzip` restores the mode recorded in the archive. Nothing else does
@@ -205,7 +243,7 @@ async fn move_into(dir: &Path, path: &Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_archive, install_archive};
+    use super::{extract_archive, install_archive, is_corrupt_archive};
 
     /// Compression method 0: the payload is stored verbatim.
     const STORED: u16 = 0;
@@ -583,6 +621,63 @@ mod tests {
                 .as_bytes()
         );
         assert_eq!(mode_of(&dir.path().join("compactc")), 0o755);
+    }
+
+    /// A wrong checksum means the bytes on disk are not the archive that was
+    /// published, so fetching it again is the way out. The caller keys its
+    /// retry off this, hence a test for the classification and not only for the
+    /// failure.
+    #[test]
+    fn a_failed_checksum_is_the_archives_fault() {
+        let dir = artifact_dir(&[file("compactc", b"compiler", 0o755)]);
+        let path = zip_in(dir.path());
+
+        let mut bytes = std::fs::read(&path).expect("archive");
+        let at = bytes
+            .windows(8)
+            .position(|window| window == b"compiler")
+            .expect("payload");
+        bytes[at] = b'X';
+        std::fs::write(&path, &bytes).expect("Failed to corrupt the archive");
+
+        let error = extract_archive(dir.path(), &path).expect_err("A bad checksum must fail");
+
+        assert!(
+            is_corrupt_archive(&error),
+            "a bad checksum should be blamed on the archive: {error:#}"
+        );
+    }
+
+    #[test]
+    fn a_file_that_is_not_an_archive_is_the_archives_fault() {
+        let dir = tempfile::tempdir().expect("temporary directory");
+        std::fs::write(zip_in(dir.path()), b"this is not a zip file").expect("write");
+
+        let error =
+            extract_archive(dir.path(), &zip_in(dir.path())).expect_err("Not an archive must fail");
+
+        assert!(
+            is_corrupt_archive(&error),
+            "an unreadable file should be blamed on the archive: {error:#}"
+        );
+    }
+
+    /// The counterpart: a failure to write is the machine's problem, and
+    /// fetching the archive again would only waste the download.
+    #[test]
+    fn a_failure_to_write_is_not_the_archives_fault() {
+        let dir = artifact_dir(&[file("compactc", b"compiler", 0o755)]);
+
+        let error = extract_archive(
+            std::path::Path::new("/compact-test/no/such/directory"),
+            &zip_in(dir.path()),
+        )
+        .expect_err("Writing into a directory that does not exist must fail");
+
+        assert!(
+            !is_corrupt_archive(&error),
+            "a write failure should not be blamed on the archive: {error:#}"
+        );
     }
 
     #[test]

--- a/tools/compact/src/compiler_legacy.rs
+++ b/tools/compact/src/compiler_legacy.rs
@@ -13,18 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
 use reqwest::Url;
 use semver::Version;
-use std::{
-    io::ErrorKind,
-    path::{Path, PathBuf},
-    process::Stdio,
-};
-use tokio::{fs, process::Command};
-
-/// External command used to unpack a downloaded toolchain archive.
-pub const EXTRACTION_COMMAND: &str = "unzip";
+use std::path::{Path, PathBuf};
+use tokio::fs;
 
 /// The compiler binary, whose presence callers take as proof that a version is
 /// completely installed.
@@ -55,69 +48,66 @@ impl CompilerAsset {
         &self.asset.browser_download_url
     }
 
-    pub async fn unzip(&self) -> Result<()> {
-        install_archive(EXTRACTION_COMMAND, &self.path, &self.path_zip()).await
+    pub async fn install(&self) -> Result<()> {
+        install_archive(&self.path, &self.path_zip()).await
     }
 }
 
-/// Unpack `zip` into `dir` using an external extraction command.
+/// Unpack `zip` into `dir`.
 ///
-/// `command` is a parameter rather than a constant so that the error path can
-/// be tested without touching the process environment.
-async fn extract_archive(command: &str, dir: &Path, zip: &Path) -> Result<()> {
-    let mut cmd = Command::new(command);
+/// The toolchain used to be unpacked by running `unzip`, which is not installed
+/// by default on many systems -- the machine in issue #739 had `tar`, `gzip`,
+/// `xz` and `zstd` but not `unzip`, so the toolchain could not be installed at
+/// all. Reading the archive here removes that dependency.
+///
+/// The release archive is produced by `zip --junk-paths` (see
+/// `.github/workflows/release-build.yml`), so it is a flat set of regular
+/// files. Entries are written by their file name alone, which also means a
+/// hand-made archive cannot direct a write outside `dir`.
+fn extract_archive(dir: &Path, zip: &Path) -> Result<()> {
+    let file = std::fs::File::open(zip).with_context(|| anyhow!("Failed to open `{zip:?}'"))?;
 
-    // execute the extraction command in the artifact directory
-    cmd.current_dir(dir);
+    let mut archive = zip::ZipArchive::new(file)
+        .with_context(|| anyhow!("Failed to read `{zip:?}' as a zip archive"))?;
 
-    // `-o' overwrites without asking. Standard input is closed below, so an
-    // overwrite prompt left behind by a partially extracted archive would fail
-    // the retry instead of repairing it.
-    cmd.arg("-o");
-    cmd.arg(zip);
+    for index in 0..archive.len() {
+        let mut entry = archive
+            .by_index(index)
+            .with_context(|| anyhow!("Failed to read entry {index} of `{zip:?}'"))?;
 
-    // capture the StdOut and StdErr
-    cmd.stdout(Stdio::piped());
-    cmd.stderr(Stdio::piped());
-
-    // don't allow StdIn, we don't have anything to pass in the standard input
-    // and we don't want it to be inherited
-    cmd.stdin(Stdio::null());
-
-    let child = cmd.spawn().map_err(|error| {
-        // A bare `Failed to spawn artifact extraction command' plus the OS
-        // error names neither the missing command nor a way to fix it.
-        if error.kind() == ErrorKind::NotFound {
-            anyhow!(
-                "Failed to unpack the toolchain: `{command}' was not found. The \
-                 Compact toolchain is distributed as a zip archive, so `{command}' \
-                 must be installed and on your PATH; install it and run the same \
-                 command again."
-            )
-        } else {
-            anyhow::Error::new(error).context(format!(
-                "Failed to spawn the extraction command `{command}'"
-            ))
+        if entry.is_dir() {
+            continue;
         }
-    })?;
 
-    let output = child
-        .wait_with_output()
-        .await
-        .context("Failed to execute the artifact extraction command")?;
+        let Some(name) = entry.enclosed_name() else {
+            bail!("Refusing entry {index} of `{zip:?}': its name escapes the archive");
+        };
 
-    let status = output.status;
+        let Some(name) = name.file_name().map(|name| name.to_owned()) else {
+            continue;
+        };
 
-    if status.success() {
-        Ok(())
-    } else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        let target = dir.join(name);
 
-        Err(anyhow!("Stderr: {stderr}"))
-            .with_context(|| anyhow!("Status: {status}"))
-            .with_context(|| anyhow!("Command={command} CWD={dir:?}"))
-            .context("artifact Extraction failed")
+        let mut output = std::fs::File::create(&target)
+            .with_context(|| anyhow!("Failed to create `{target:?}'"))?;
+
+        std::io::copy(&mut entry, &mut output)
+            .with_context(|| anyhow!("Failed to write `{target:?}'"))?;
+
+        // `unzip` restores the mode recorded in the archive. Nothing else does
+        // it for us, and a `compactc` without its executable bit is an
+        // installation that looks complete and cannot run.
+        #[cfg(unix)]
+        if let Some(mode) = entry.unix_mode() {
+            use std::os::unix::fs::PermissionsExt;
+
+            std::fs::set_permissions(&target, std::fs::Permissions::from_mode(mode))
+                .with_context(|| anyhow!("Failed to set the mode of `{target:?}'"))?;
+        }
     }
+
+    Ok(())
 }
 
 /// Unpack `zip` into `dir` so that a partial result can never be mistaken for a
@@ -129,7 +119,7 @@ async fn extract_archive(command: &str, dir: &Path, zip: &Path) -> Result<()> {
 /// interrupted extraction that got as far as writing that one file leaves
 /// something that looks installed and is not -- the same mistake, one level
 /// down, as trusting the version directory to exist.
-async fn install_archive(command: &str, dir: &Path, zip: &Path) -> Result<()> {
+async fn install_archive(dir: &Path, zip: &Path) -> Result<()> {
     let staging = dir.join(STAGING_DIR);
 
     // An earlier attempt may have been interrupted part-way through unpacking.
@@ -144,7 +134,12 @@ async fn install_archive(command: &str, dir: &Path, zip: &Path) -> Result<()> {
         .await
         .with_context(|| anyhow!("Failed to create `{staging:?}'"))?;
 
-    extract_archive(command, &staging, zip).await?;
+    // reading and inflating an archive is blocking work
+    let unpack_into = staging.clone();
+    let unpack = zip.to_path_buf();
+    tokio::task::spawn_blocking(move || extract_archive(&unpack_into, &unpack))
+        .await
+        .context("The task unpacking the archive did not finish")??;
 
     let mut compiler = None;
     let mut rest = Vec::new();
@@ -210,8 +205,29 @@ async fn move_into(dir: &Path, path: &Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{EXTRACTION_COMMAND, extract_archive, install_archive};
-    use std::path::Path;
+    use super::{extract_archive, install_archive};
+
+    /// Compression method 0: the payload is stored verbatim.
+    const STORED: u16 = 0;
+    /// Compression method 12: bzip2, which this build deliberately does not
+    /// enable. Useful for making one entry unreadable on purpose.
+    const UNSUPPORTED: u16 = 12;
+
+    struct Entry<'a> {
+        name: &'a str,
+        contents: &'a [u8],
+        mode: u32,
+        method: u16,
+    }
+
+    fn file<'a>(name: &'a str, contents: &'static [u8], mode: u32) -> Entry<'a> {
+        Entry {
+            name,
+            contents,
+            mode,
+            method: STORED,
+        }
+    }
 
     /// CRC-32 (IEEE), computed here so the test needs no extra dependency.
     fn crc32(data: &[u8]) -> u32 {
@@ -232,23 +248,24 @@ mod tests {
         !crc
     }
 
-    /// A zip holding each entry uncompressed. Names may contain `/`, which the
-    /// extraction command turns into directories.
-    fn stored_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    /// Build a zip holding each entry, recording its unix mode and compression
+    /// method so a test can ask for one that cannot be read.
+    fn zip_of(entries: &[Entry]) -> Vec<u8> {
         let mut zip = Vec::new();
         let mut central = Vec::new();
 
-        for (name, contents) in entries {
-            let name = name.as_bytes();
-            let crc = crc32(contents).to_le_bytes();
-            let size = (contents.len() as u32).to_le_bytes();
+        for entry in entries {
+            let name = entry.name.as_bytes();
+            let crc = crc32(entry.contents).to_le_bytes();
+            let size = (entry.contents.len() as u32).to_le_bytes();
             let name_len = (name.len() as u16).to_le_bytes();
+            let method = entry.method.to_le_bytes();
             let offset = (zip.len() as u32).to_le_bytes();
 
             zip.extend_from_slice(b"PK\x03\x04"); // local file header
             zip.extend_from_slice(&[20, 0]); // version needed
             zip.extend_from_slice(&[0, 0]); // flags
-            zip.extend_from_slice(&[0, 0]); // method 0: stored
+            zip.extend_from_slice(&method);
             zip.extend_from_slice(&[0, 0, 0, 0]); // mtime, mdate
             zip.extend_from_slice(&crc);
             zip.extend_from_slice(&size); // compressed size
@@ -256,13 +273,13 @@ mod tests {
             zip.extend_from_slice(&name_len);
             zip.extend_from_slice(&[0, 0]); // extra length
             zip.extend_from_slice(name);
-            zip.extend_from_slice(contents);
+            zip.extend_from_slice(entry.contents);
 
             central.extend_from_slice(b"PK\x01\x02"); // central directory header
-            central.extend_from_slice(&[20, 0]); // version made by
+            central.extend_from_slice(&[20, 3]); // version made by: 3 = unix
             central.extend_from_slice(&[20, 0]); // version needed
             central.extend_from_slice(&[0, 0]); // flags
-            central.extend_from_slice(&[0, 0]); // method
+            central.extend_from_slice(&method);
             central.extend_from_slice(&[0, 0, 0, 0]); // mtime, mdate
             central.extend_from_slice(&crc);
             central.extend_from_slice(&size);
@@ -272,7 +289,7 @@ mod tests {
             central.extend_from_slice(&[0, 0]); // comment length
             central.extend_from_slice(&[0, 0]); // disk number
             central.extend_from_slice(&[0, 0]); // internal attributes
-            central.extend_from_slice(&[0, 0, 0, 0]); // external attributes
+            central.extend_from_slice(&(entry.mode << 16).to_le_bytes()); // external attributes
             central.extend_from_slice(&offset);
             central.extend_from_slice(name);
         }
@@ -296,90 +313,158 @@ mod tests {
 
     /// An artifact directory holding nothing but `artifact.zip` -- the state a
     /// failed extraction leaves behind.
-    fn artifact_dir(entries: &[(&str, &[u8])]) -> tempfile::TempDir {
+    fn artifact_dir(entries: &[Entry]) -> tempfile::TempDir {
         let dir = tempfile::tempdir().expect("Failed to create a temporary directory");
 
-        std::fs::write(dir.path().join("artifact.zip"), stored_zip(entries))
+        std::fs::write(dir.path().join("artifact.zip"), zip_of(entries))
             .expect("Failed to write artifact.zip");
 
         dir
     }
 
-    fn zip_in(dir: &Path) -> std::path::PathBuf {
+    fn zip_in(dir: &std::path::Path) -> std::path::PathBuf {
         dir.join("artifact.zip")
     }
 
-    const COMPILER: &[(&str, &[u8])] = &[("compactc", b"binary")];
+    #[cfg(unix)]
+    fn mode_of(path: &std::path::Path) -> u32 {
+        use std::os::unix::fs::PermissionsExt;
 
-    #[tokio::test]
-    async fn extracts_the_compiler_from_the_archive() {
-        let dir = artifact_dir(COMPILER);
+        std::fs::metadata(path)
+            .expect("Failed to stat the extracted file")
+            .permissions()
+            .mode()
+            & 0o777
+    }
 
-        extract_archive(EXTRACTION_COMMAND, dir.path(), &zip_in(dir.path()))
-            .await
-            .expect("Extraction should succeed");
+    #[test]
+    fn extracts_every_entry() {
+        let dir = artifact_dir(&[
+            file("compactc", b"compiler", 0o755),
+            file("format-compact", b"formatter", 0o755),
+            file("public_params.bin", b"params", 0o644),
+        ]);
+
+        extract_archive(dir.path(), &zip_in(dir.path())).expect("Extraction should succeed");
 
         assert_eq!(
-            std::fs::read(dir.path().join("compactc")).expect("Failed to read compactc"),
-            b"binary"
+            std::fs::read(dir.path().join("compactc")).expect("compactc"),
+            b"compiler"
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join("format-compact")).expect("format-compact"),
+            b"formatter"
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join("public_params.bin")).expect("public_params.bin"),
+            b"params"
         );
     }
 
-    /// Issue #739: a retry runs over whatever the failed attempt left behind, so
-    /// extraction has to overwrite rather than stop at an overwrite prompt --
-    /// standard input is closed, so a prompt fails the retry.
+    /// `unzip` restored the mode from the archive and nothing does it for us
+    /// now, so a compiler extracted without its executable bit would look
+    /// installed and refuse to run.
+    #[cfg(unix)]
+    #[test]
+    fn the_extracted_compiler_is_executable() {
+        let dir = artifact_dir(&[file("compactc", b"compiler", 0o755)]);
+
+        extract_archive(dir.path(), &zip_in(dir.path())).expect("Extraction should succeed");
+
+        assert_eq!(mode_of(&dir.path().join("compactc")), 0o755);
+    }
+
+    /// ...and the mode is taken from the archive rather than applied to
+    /// everything, so a data file does not come out executable.
+    #[cfg(unix)]
+    #[test]
+    fn a_file_that_is_not_executable_in_the_archive_stays_that_way() {
+        let dir = artifact_dir(&[file("public_params.bin", b"params", 0o644)]);
+
+        extract_archive(dir.path(), &zip_in(dir.path())).expect("Extraction should succeed");
+
+        assert_eq!(mode_of(&dir.path().join("public_params.bin")), 0o644);
+    }
+
+    /// The archive is unpacked read-only; a compiler stored read-only in the
+    /// archive must still be replaceable by a later install.
+    #[cfg(unix)]
     #[tokio::test]
-    async fn re_extraction_overwrites_a_partial_result() {
-        let dir = artifact_dir(COMPILER);
+    async fn a_read_only_compiler_can_still_be_reinstalled() {
+        let dir = artifact_dir(&[file("compactc", b"first", 0o555)]);
 
-        // a truncated leftover from an interrupted extraction
-        std::fs::write(dir.path().join("compactc"), b"trunc")
-            .expect("Failed to write the partial file");
-
-        extract_archive(EXTRACTION_COMMAND, dir.path(), &zip_in(dir.path()))
+        install_archive(dir.path(), &zip_in(dir.path()))
             .await
-            .expect("Re-extraction should overwrite rather than prompt");
+            .expect("The first installation should succeed");
+        assert_eq!(mode_of(&dir.path().join("compactc")), 0o555);
+
+        std::fs::write(
+            zip_in(dir.path()),
+            zip_of(&[file("compactc", b"second", 0o555)]),
+        )
+        .expect("Failed to replace the archive");
+
+        install_archive(dir.path(), &zip_in(dir.path()))
+            .await
+            .expect("Reinstalling over a read-only compiler should succeed");
 
         assert_eq!(
-            std::fs::read(dir.path().join("compactc")).expect("Failed to read compactc"),
-            b"binary"
+            std::fs::read(dir.path().join("compactc")).expect("compactc"),
+            b"second"
         );
     }
 
-    /// Issue #739: an absent extraction command reported only as
-    /// `No such file or directory (os error 2)' tells the user nothing. The
-    /// error has to name the command and say what to do about it.
+    #[test]
+    fn an_entry_that_cannot_be_decompressed_is_an_error() {
+        let dir = artifact_dir(&[
+            file("compactc", b"compiler", 0o755),
+            Entry {
+                name: "public_params.bin",
+                contents: b"params",
+                mode: 0o644,
+                method: UNSUPPORTED,
+            },
+        ]);
+
+        extract_archive(dir.path(), &zip_in(dir.path()))
+            .expect_err("An entry that cannot be decompressed must fail");
+    }
+
+    /// Issue #739, one level down: callers treat the presence of `compactc' as
+    /// proof that a version is installed, so an extraction that fails partway
+    /// must not leave that file behind. Here the compiler is the first entry
+    /// and the second cannot be read, so extraction fails after `compactc' has
+    /// been written into the staging directory.
     #[tokio::test]
-    async fn a_missing_extraction_command_is_named() {
-        let dir = artifact_dir(COMPILER);
-        let missing = "compact-test-no-such-extraction-command";
+    async fn a_failed_installation_leaves_no_compiler_in_place() {
+        let dir = artifact_dir(&[
+            file("compactc", b"compiler", 0o755),
+            Entry {
+                name: "public_params.bin",
+                contents: b"params",
+                mode: 0o644,
+                method: UNSUPPORTED,
+            },
+        ]);
 
-        let error = extract_archive(missing, dir.path(), &zip_in(dir.path()))
+        install_archive(dir.path(), &zip_in(dir.path()))
             .await
-            .expect_err("A missing extraction command must fail");
-
-        let message = format!("{error:#}");
+            .expect_err("A failed extraction must fail the installation");
 
         assert!(
-            message.contains(missing),
-            "the error should name the missing command: {message}"
-        );
-        assert!(
-            message.contains("PATH"),
-            "the error should say where the command is looked for: {message}"
+            !dir.path().join("compactc").exists(),
+            "a failed installation must not leave something that looks installed"
         );
     }
 
     #[tokio::test]
     async fn installs_every_entry_and_clears_the_staging_directory() {
-        let entries: &[(&str, &[u8])] = &[
-            ("compactc", b"compiler"),
-            ("format-compact", b"formatter"),
-            ("lib/helper", b"library"),
-        ];
-        let dir = artifact_dir(entries);
+        let dir = artifact_dir(&[
+            file("compactc", b"compiler", 0o755),
+            file("format-compact", b"formatter", 0o755),
+        ]);
 
-        install_archive(EXTRACTION_COMMAND, dir.path(), &zip_in(dir.path()))
+        install_archive(dir.path(), &zip_in(dir.path()))
             .await
             .expect("Installation should succeed");
 
@@ -391,68 +476,32 @@ mod tests {
             std::fs::read(dir.path().join("format-compact")).expect("format-compact"),
             b"formatter"
         );
-        assert_eq!(
-            std::fs::read(dir.path().join("lib").join("helper")).expect("lib/helper"),
-            b"library"
-        );
         assert!(
             !dir.path().join(".incoming").exists(),
             "the staging directory should not survive a successful installation"
         );
-    }
-
-    /// Issue #739, one level down: callers treat the presence of `compactc' as
-    /// proof that a version is installed, so an extraction that fails partway
-    /// must not leave that file behind. Unpacking straight into the version
-    /// directory did exactly that whenever the failure came after the compiler
-    /// binary had been written -- a full disk, a killed process, a corrupt
-    /// archive -- and the next run then reported "already installed" over a
-    /// broken installation.
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn an_extraction_that_fails_after_writing_the_compiler_installs_nothing() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let dir = artifact_dir(COMPILER);
-
-        // stands in for an extraction that reaches the compiler binary and then
-        // dies; it runs in the directory it is told to unpack into
-        let script = dir.path().join("half-extract");
-        std::fs::write(&script, "#!/bin/sh\nprintf partial > compactc\nexit 1\n")
-            .expect("Failed to write the stub");
-        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
-            .expect("Failed to make the stub executable");
-
-        install_archive(
-            script.to_str().expect("stub path"),
-            dir.path(),
-            &zip_in(dir.path()),
-        )
-        .await
-        .expect_err("A failed extraction must fail the installation");
-
         assert!(
-            !dir.path().join("compactc").exists(),
-            "a failed installation must not leave something that looks installed"
+            zip_in(dir.path()).is_file(),
+            "the archive itself should not be moved into place"
         );
     }
 
     #[tokio::test]
     async fn leftovers_from_an_interrupted_attempt_are_discarded() {
-        let dir = artifact_dir(COMPILER);
+        let dir = artifact_dir(&[file("compactc", b"compiler", 0o755)]);
 
         let staging = dir.path().join(".incoming");
         std::fs::create_dir_all(&staging).expect("staging");
         std::fs::write(staging.join("compactc"), b"stale").expect("stale compiler");
         std::fs::write(staging.join("junk"), b"junk").expect("junk");
 
-        install_archive(EXTRACTION_COMMAND, dir.path(), &zip_in(dir.path()))
+        install_archive(dir.path(), &zip_in(dir.path()))
             .await
             .expect("Installation should succeed");
 
         assert_eq!(
             std::fs::read(dir.path().join("compactc")).expect("compactc"),
-            b"binary"
+            b"compiler"
         );
         assert!(
             !dir.path().join("junk").exists(),
@@ -460,26 +509,93 @@ mod tests {
         );
     }
 
+    /// A broken installation can leave a directory where a file belongs;
+    /// `rename` will not replace a directory that has anything in it.
     #[tokio::test]
-    async fn installing_replaces_a_directory_that_is_already_there() {
-        let entries: &[(&str, &[u8])] = &[("compactc", b"binary"), ("lib/helper", b"new")];
-        let dir = artifact_dir(entries);
+    async fn installing_replaces_a_directory_left_where_a_file_belongs() {
+        let dir = artifact_dir(&[file("compactc", b"compiler", 0o755)]);
 
-        let lib = dir.path().join("lib");
-        std::fs::create_dir_all(&lib).expect("lib");
-        std::fs::write(lib.join("stale"), b"stale").expect("stale");
+        let wrong = dir.path().join("compactc");
+        std::fs::create_dir_all(&wrong).expect("directory");
+        std::fs::write(wrong.join("junk"), b"junk").expect("junk");
 
-        install_archive(EXTRACTION_COMMAND, dir.path(), &zip_in(dir.path()))
+        install_archive(dir.path(), &zip_in(dir.path()))
             .await
             .expect("Installation should succeed");
 
         assert_eq!(
-            std::fs::read(lib.join("helper")).expect("lib/helper"),
-            b"new"
+            std::fs::read(dir.path().join("compactc")).expect("compactc"),
+            b"compiler"
         );
+    }
+
+    /// The release archive is flat, but nothing about a downloaded file
+    /// guarantees that. An entry naming a path outside the directory must not
+    /// be followed.
+    #[test]
+    fn an_entry_whose_name_escapes_the_archive_is_refused() {
+        let dir = artifact_dir(&[file("../escaped", b"nope", 0o644)]);
+
+        extract_archive(dir.path(), &zip_in(dir.path()))
+            .expect_err("An entry naming a path outside the archive must be refused");
+
         assert!(
-            !lib.join("stale").exists(),
-            "a replaced directory should not keep its old contents"
+            !dir.path().parent().unwrap().join("escaped").exists(),
+            "nothing may be written outside the destination directory"
+        );
+    }
+
+    /// Every other test here stores its entries uncompressed, but the release
+    /// archive is built by `zip --junk-paths`, which deflates. If the crate's
+    /// deflate feature were ever dropped from Cargo.toml the stored-entry tests
+    /// would all still pass and every real installation would fail, so this one
+    /// carries a genuinely deflated archive: 536 bytes compressed to 69.
+    #[cfg(unix)]
+    #[test]
+    fn extracts_a_deflated_archive() {
+        const DEFLATED: &[u8] = &[
+            0x50, 0x4b, 0x03, 0x04, 0x14, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x21, 0x00,
+            0x9c, 0x7d, 0xd0, 0xdf, 0x45, 0x00, 0x00, 0x00, 0x18, 0x02, 0x00, 0x00, 0x08, 0x00,
+            0x00, 0x00, 0x63, 0x6f, 0x6d, 0x70, 0x61, 0x63, 0x74, 0x63, 0xed, 0x8c, 0xc1, 0x0d,
+            0x80, 0x30, 0x0c, 0x03, 0x57, 0xf1, 0x00, 0x88, 0x9d, 0x42, 0x6a, 0x68, 0x25, 0x9a,
+            0x54, 0x6d, 0x3e, 0x6c, 0x4f, 0xe6, 0x40, 0xfc, 0xce, 0x3a, 0xf9, 0xd4, 0xfb, 0x10,
+            0x0d, 0xc5, 0xd1, 0x4c, 0xe6, 0x03, 0x75, 0x0b, 0x5a, 0xac, 0x0d, 0x93, 0x83, 0x12,
+            0x2c, 0x58, 0x8e, 0xc2, 0xf3, 0x4e, 0x46, 0x95, 0x95, 0xb3, 0x33, 0x6a, 0xb3, 0x0b,
+            0x91, 0xc2, 0xf7, 0xbc, 0xfc, 0x89, 0xcf, 0x25, 0x5e, 0x50, 0x4b, 0x01, 0x02, 0x14,
+            0x03, 0x14, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x21, 0x00, 0x9c, 0x7d, 0xd0,
+            0xdf, 0x45, 0x00, 0x00, 0x00, 0x18, 0x02, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xed, 0x01, 0x00, 0x00, 0x00, 0x00, 0x63,
+            0x6f, 0x6d, 0x70, 0x61, 0x63, 0x74, 0x63, 0x50, 0x4b, 0x05, 0x06, 0x00, 0x00, 0x00,
+            0x00, 0x01, 0x00, 0x01, 0x00, 0x36, 0x00, 0x00, 0x00, 0x6b, 0x00, 0x00, 0x00, 0x00,
+            0x00,
+        ];
+
+        let dir = tempfile::tempdir().expect("temporary directory");
+        std::fs::write(zip_in(dir.path()), DEFLATED).expect("Failed to write the archive");
+
+        extract_archive(dir.path(), &zip_in(dir.path()))
+            .expect("A deflated archive should extract");
+
+        assert_eq!(
+            std::fs::read(dir.path().join("compactc")).expect("compactc"),
+            "compactc binary contents, repeated so deflate has something to do. "
+                .repeat(8)
+                .as_bytes()
+        );
+        assert_eq!(mode_of(&dir.path().join("compactc")), 0o755);
+    }
+
+    #[test]
+    fn a_file_that_is_not_an_archive_is_rejected() {
+        let dir = tempfile::tempdir().expect("temporary directory");
+        std::fs::write(zip_in(dir.path()), b"this is not a zip file").expect("write");
+
+        let error = extract_archive(dir.path(), &zip_in(dir.path()))
+            .expect_err("A file that is not an archive must be rejected");
+
+        assert!(
+            format!("{error:#}").contains("zip archive"),
+            "the error should say the file is not a zip archive: {error:#}"
         );
     }
 }

--- a/tools/compact/src/compiler_legacy.rs
+++ b/tools/compact/src/compiler_legacy.rs
@@ -16,8 +16,15 @@
 use anyhow::{Context, Result, anyhow};
 use reqwest::Url;
 use semver::Version;
-use std::{path::PathBuf, process::Stdio};
+use std::{
+    io::ErrorKind,
+    path::{Path, PathBuf},
+    process::Stdio,
+};
 use tokio::process::Command;
+
+/// External command used to unpack a downloaded toolchain archive.
+pub const EXTRACTION_COMMAND: &str = "unzip";
 
 pub struct CompilerAsset {
     pub path: PathBuf,
@@ -42,39 +49,228 @@ impl CompilerAsset {
     }
 
     pub async fn unzip(&self) -> Result<()> {
-        let cwd = &self.path;
+        extract_archive(EXTRACTION_COMMAND, &self.path, &self.path_zip()).await
+    }
+}
 
-        let mut cmd = Command::new("unzip");
+/// Unpack `zip` into `dir` using an external extraction command.
+///
+/// `command` is a parameter rather than a constant so that the error path can
+/// be tested without touching the process environment.
+async fn extract_archive(command: &str, dir: &Path, zip: &Path) -> Result<()> {
+    let mut cmd = Command::new(command);
 
-        // execute the unzip command in the artifact directory
-        cmd.current_dir(cwd);
-        cmd.arg(self.path_zip());
+    // execute the extraction command in the artifact directory
+    cmd.current_dir(dir);
 
-        // capture the StdOut and StdErr
-        cmd.stdout(Stdio::piped());
-        cmd.stderr(Stdio::piped());
+    // `-o' overwrites without asking. Standard input is closed below, so an
+    // overwrite prompt left behind by a partially extracted archive would fail
+    // the retry instead of repairing it.
+    cmd.arg("-o");
+    cmd.arg(zip);
 
-        // don't allow StdIn, we don't have anything to pass in the standard
-        // input and we don't want it to be inherited
-        cmd.stdin(Stdio::null());
+    // capture the StdOut and StdErr
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
 
-        let child = cmd
-            .spawn()
-            .context("Failed to spawn artifact extraction command")?;
+    // don't allow StdIn, we don't have anything to pass in the standard input
+    // and we don't want it to be inherited
+    cmd.stdin(Stdio::null());
 
-        let output = child
-            .wait_with_output()
-            .await
-            .context("Failed to execute the artifact extraction command")?;
-        let status = output.status;
-        if !status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            Err(anyhow!("Stderr: {stderr}"))
-                .with_context(|| anyhow!("Status: {status}"))
-                .with_context(|| anyhow!("Command=unzip CWD={cwd:?}"))
-                .context("artifact Extraction failed")
+    let child = cmd.spawn().map_err(|error| {
+        // A bare `Failed to spawn artifact extraction command' plus the OS
+        // error names neither the missing command nor a way to fix it.
+        if error.kind() == ErrorKind::NotFound {
+            anyhow!(
+                "Failed to unpack the toolchain: `{command}' was not found. The \
+                 Compact toolchain is distributed as a zip archive, so `{command}' \
+                 must be installed and on your PATH; install it and run the same \
+                 command again."
+            )
         } else {
-            Ok(())
+            anyhow::Error::new(error).context(format!(
+                "Failed to spawn the extraction command `{command}'"
+            ))
         }
+    })?;
+
+    let output = child
+        .wait_with_output()
+        .await
+        .context("Failed to execute the artifact extraction command")?;
+
+    let status = output.status;
+
+    if status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        Err(anyhow!("Stderr: {stderr}"))
+            .with_context(|| anyhow!("Status: {status}"))
+            .with_context(|| anyhow!("Command={command} CWD={dir:?}"))
+            .context("artifact Extraction failed")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EXTRACTION_COMMAND, extract_archive};
+
+    /// CRC-32 (IEEE), computed here so the test needs no extra dependency.
+    fn crc32(data: &[u8]) -> u32 {
+        let mut crc = 0xFFFF_FFFFu32;
+
+        for byte in data {
+            crc ^= u32::from(*byte);
+
+            for _ in 0..8 {
+                crc = if crc & 1 == 1 {
+                    (crc >> 1) ^ 0xEDB8_8320
+                } else {
+                    crc >> 1
+                };
+            }
+        }
+
+        !crc
+    }
+
+    /// A single-entry zip holding `contents` uncompressed under `name`.
+    fn stored_zip(name: &str, contents: &[u8]) -> Vec<u8> {
+        let name = name.as_bytes();
+        let crc = crc32(contents).to_le_bytes();
+        let size = (contents.len() as u32).to_le_bytes();
+        let name_len = (name.len() as u16).to_le_bytes();
+
+        let mut zip = Vec::new();
+        zip.extend_from_slice(b"PK\x03\x04"); // local file header
+        zip.extend_from_slice(&[20, 0]); // version needed
+        zip.extend_from_slice(&[0, 0]); // flags
+        zip.extend_from_slice(&[0, 0]); // method 0: stored
+        zip.extend_from_slice(&[0, 0, 0, 0]); // mtime, mdate
+        zip.extend_from_slice(&crc);
+        zip.extend_from_slice(&size); // compressed size
+        zip.extend_from_slice(&size); // uncompressed size
+        zip.extend_from_slice(&name_len);
+        zip.extend_from_slice(&[0, 0]); // extra length
+        zip.extend_from_slice(name);
+        zip.extend_from_slice(contents);
+
+        let central_offset = (zip.len() as u32).to_le_bytes();
+
+        let mut central = Vec::new();
+        central.extend_from_slice(b"PK\x01\x02"); // central directory header
+        central.extend_from_slice(&[20, 0]); // version made by
+        central.extend_from_slice(&[20, 0]); // version needed
+        central.extend_from_slice(&[0, 0]); // flags
+        central.extend_from_slice(&[0, 0]); // method
+        central.extend_from_slice(&[0, 0, 0, 0]); // mtime, mdate
+        central.extend_from_slice(&crc);
+        central.extend_from_slice(&size);
+        central.extend_from_slice(&size);
+        central.extend_from_slice(&name_len);
+        central.extend_from_slice(&[0, 0]); // extra length
+        central.extend_from_slice(&[0, 0]); // comment length
+        central.extend_from_slice(&[0, 0]); // disk number
+        central.extend_from_slice(&[0, 0]); // internal attributes
+        central.extend_from_slice(&[0, 0, 0, 0]); // external attributes
+        central.extend_from_slice(&0u32.to_le_bytes()); // local header offset
+        central.extend_from_slice(name);
+
+        let central_len = (central.len() as u32).to_le_bytes();
+
+        zip.extend_from_slice(&central);
+        zip.extend_from_slice(b"PK\x05\x06"); // end of central directory
+        zip.extend_from_slice(&[0, 0]); // this disk
+        zip.extend_from_slice(&[0, 0]); // disk holding the central directory
+        zip.extend_from_slice(&[1, 0]); // entries on this disk
+        zip.extend_from_slice(&[1, 0]); // entries in total
+        zip.extend_from_slice(&central_len);
+        zip.extend_from_slice(&central_offset);
+        zip.extend_from_slice(&[0, 0]); // comment length
+
+        zip
+    }
+
+    /// An artifact directory holding nothing but `artifact.zip` -- the state a
+    /// failed extraction leaves behind.
+    fn artifact_dir(contents: &[u8]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("Failed to create a temporary directory");
+
+        std::fs::write(
+            dir.path().join("artifact.zip"),
+            stored_zip("compactc", contents),
+        )
+        .expect("Failed to write artifact.zip");
+
+        dir
+    }
+
+    #[tokio::test]
+    async fn extracts_the_compiler_from_the_archive() {
+        let dir = artifact_dir(b"binary");
+
+        extract_archive(
+            EXTRACTION_COMMAND,
+            dir.path(),
+            &dir.path().join("artifact.zip"),
+        )
+        .await
+        .expect("Extraction should succeed");
+
+        assert_eq!(
+            std::fs::read(dir.path().join("compactc")).expect("Failed to read compactc"),
+            b"binary"
+        );
+    }
+
+    /// Issue #739: a retry runs over whatever the failed attempt left behind, so
+    /// extraction has to overwrite rather than stop at an overwrite prompt --
+    /// standard input is closed, so a prompt fails the retry.
+    #[tokio::test]
+    async fn re_extraction_overwrites_a_partial_result() {
+        let dir = artifact_dir(b"binary");
+
+        // a truncated leftover from an interrupted extraction
+        std::fs::write(dir.path().join("compactc"), b"trunc")
+            .expect("Failed to write the partial file");
+
+        extract_archive(
+            EXTRACTION_COMMAND,
+            dir.path(),
+            &dir.path().join("artifact.zip"),
+        )
+        .await
+        .expect("Re-extraction should overwrite rather than prompt");
+
+        assert_eq!(
+            std::fs::read(dir.path().join("compactc")).expect("Failed to read compactc"),
+            b"binary"
+        );
+    }
+
+    /// Issue #739: an absent extraction command reported only as
+    /// `No such file or directory (os error 2)' tells the user nothing. The
+    /// error has to name the command and say what to do about it.
+    #[tokio::test]
+    async fn a_missing_extraction_command_is_named() {
+        let dir = artifact_dir(b"binary");
+        let missing = "compact-test-no-such-extraction-command";
+
+        let error = extract_archive(missing, dir.path(), &dir.path().join("artifact.zip"))
+            .await
+            .expect_err("A missing extraction command must fail");
+
+        let message = format!("{error:#}");
+
+        assert!(
+            message.contains(missing),
+            "the error should name the missing command: {message}"
+        );
+        assert!(
+            message.contains("PATH"),
+            "the error should say where the command is looked for: {message}"
+        );
     }
 }

--- a/tools/compact/src/compiler_legacy.rs
+++ b/tools/compact/src/compiler_legacy.rs
@@ -136,9 +136,19 @@ fn extract_archive(dir: &Path, zip: &Path) -> Result<()> {
         // `unzip` restores the mode recorded in the archive. Nothing else does
         // it for us, and a `compactc` without its executable bit is an
         // installation that looks complete and cannot run.
+        //
+        // The recorded mode is archive data, so it is masked before use. A
+        // crafted entry could otherwise ask for group- or world-writable --
+        // letting another local user rewrite a file before it is run -- or for
+        // setuid or setgid. A symlink entry records 0o120777, which `from_mode'
+        // would turn into a world-writable regular file. Masking keeps what the
+        // release archives actually rely on, including the read-only 0o555 that
+        // the nix store ships, and drops the rest.
         #[cfg(unix)]
         if let Some(mode) = entry.unix_mode() {
             use std::os::unix::fs::PermissionsExt;
+
+            let mode = mode & 0o755;
 
             std::fs::set_permissions(&target, std::fs::Permissions::from_mode(mode))
                 .with_context(|| anyhow!("Failed to set the mode of `{target:?}'"))?;
@@ -415,6 +425,41 @@ mod tests {
     /// ...and the mode is taken from the archive rather than applied to
     /// everything, so a data file does not come out executable.
     #[cfg(unix)]
+    #[test]
+    fn a_hostile_mode_in_the_archive_is_not_honoured() {
+        // 0o4777 asks for setuid and writable-by-anyone; 0o2775 for setgid
+        // and group-writable; 0o120777 is what a symlink entry records, and
+        // `from_mode' would keep its 0o777.
+        let dir = artifact_dir(&[
+            file("compactc", b"compiler", 0o4777),
+            file("shared.bin", b"data", 0o2775),
+            file("link", b"../../../etc/passwd", 0o120777),
+        ]);
+
+        extract_archive(dir.path(), &zip_in(dir.path())).expect("Extraction should succeed");
+
+        for name in ["compactc", "shared.bin", "link"] {
+            let target = dir.path().join(name);
+
+            assert_eq!(
+                mode_of(&target),
+                0o755,
+                "`{name}' kept a mode the archive asked for"
+            );
+
+            // and the symlink entry is a regular file holding the target as its
+            // bytes, not a link: nothing here can create one
+            assert!(
+                target
+                    .symlink_metadata()
+                    .expect("stat")
+                    .file_type()
+                    .is_file(),
+                "`{name}' is not a regular file"
+            );
+        }
+    }
+
     #[test]
     fn a_file_that_is_not_executable_in_the_archive_stays_that_way() {
         let dir = artifact_dir(&[file("public_params.bin", b"params", 0o644)]);

--- a/tools/compact/src/compiler_legacy.rs
+++ b/tools/compact/src/compiler_legacy.rs
@@ -21,10 +21,17 @@ use std::{
     path::{Path, PathBuf},
     process::Stdio,
 };
-use tokio::process::Command;
+use tokio::{fs, process::Command};
 
 /// External command used to unpack a downloaded toolchain archive.
 pub const EXTRACTION_COMMAND: &str = "unzip";
+
+/// The compiler binary, whose presence callers take as proof that a version is
+/// completely installed.
+const COMPILER_BIN: &str = "compactc";
+
+/// Where an archive is unpacked before being moved into place.
+const STAGING_DIR: &str = ".incoming";
 
 pub struct CompilerAsset {
     pub path: PathBuf,
@@ -49,7 +56,7 @@ impl CompilerAsset {
     }
 
     pub async fn unzip(&self) -> Result<()> {
-        extract_archive(EXTRACTION_COMMAND, &self.path, &self.path_zip()).await
+        install_archive(EXTRACTION_COMMAND, &self.path, &self.path_zip()).await
     }
 }
 
@@ -113,9 +120,98 @@ async fn extract_archive(command: &str, dir: &Path, zip: &Path) -> Result<()> {
     }
 }
 
+/// Unpack `zip` into `dir` so that a partial result can never be mistaken for a
+/// complete installation.
+///
+/// The archive is unpacked into a staging directory and the result moved into
+/// place with the compiler binary last. Callers test for `compactc` to decide
+/// whether a version is installed, so unpacking directly into `dir` means an
+/// interrupted extraction that got as far as writing that one file leaves
+/// something that looks installed and is not -- the same mistake, one level
+/// down, as trusting the version directory to exist.
+async fn install_archive(command: &str, dir: &Path, zip: &Path) -> Result<()> {
+    let staging = dir.join(STAGING_DIR);
+
+    // An earlier attempt may have been interrupted part-way through unpacking.
+    // Start from nothing rather than unpacking over its leftovers.
+    if fs::metadata(&staging).await.is_ok() {
+        fs::remove_dir_all(&staging)
+            .await
+            .with_context(|| anyhow!("Failed to clear `{staging:?}'"))?;
+    }
+
+    fs::create_dir_all(&staging)
+        .await
+        .with_context(|| anyhow!("Failed to create `{staging:?}'"))?;
+
+    extract_archive(command, &staging, zip).await?;
+
+    let mut compiler = None;
+    let mut rest = Vec::new();
+
+    let mut entries = fs::read_dir(&staging)
+        .await
+        .with_context(|| anyhow!("Failed to read `{staging:?}'"))?;
+
+    while let Some(entry) = entries
+        .next_entry()
+        .await
+        .with_context(|| anyhow!("Failed to read `{staging:?}'"))?
+    {
+        if entry.file_name() == COMPILER_BIN {
+            compiler = Some(entry.path());
+        } else {
+            rest.push(entry.path());
+        }
+    }
+
+    for path in rest {
+        move_into(dir, &path).await?;
+    }
+
+    // last, so that nothing is outstanding once it exists
+    if let Some(path) = compiler {
+        move_into(dir, &path).await?;
+    }
+
+    fs::remove_dir_all(&staging)
+        .await
+        .with_context(|| anyhow!("Failed to remove `{staging:?}'"))?;
+
+    Ok(())
+}
+
+/// Move `path` into `dir`, replacing whatever is there.
+///
+/// `rename` is atomic within a filesystem and the staging directory is a child
+/// of `dir`, so an onlooker sees either the previous entry or the complete new
+/// one, never a half-written file.
+async fn move_into(dir: &Path, path: &Path) -> Result<()> {
+    let name = path
+        .file_name()
+        .ok_or_else(|| anyhow!("Unpacked entry has no file name: `{path:?}'"))?;
+    let target = dir.join(name);
+
+    // `rename` will not replace a directory that has anything in it.
+    match fs::metadata(&target).await {
+        Ok(metadata) if metadata.is_dir() => fs::remove_dir_all(&target)
+            .await
+            .with_context(|| anyhow!("Failed to replace `{target:?}'"))?,
+        Ok(_) => fs::remove_file(&target)
+            .await
+            .with_context(|| anyhow!("Failed to replace `{target:?}'"))?,
+        Err(_) => (),
+    }
+
+    fs::rename(path, &target)
+        .await
+        .with_context(|| anyhow!("Failed to move `{path:?}' to `{target:?}'"))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{EXTRACTION_COMMAND, extract_archive};
+    use super::{EXTRACTION_COMMAND, extract_archive, install_archive};
+    use std::path::Path;
 
     /// CRC-32 (IEEE), computed here so the test needs no extra dependency.
     fn crc32(data: &[u8]) -> u32 {
@@ -136,56 +232,61 @@ mod tests {
         !crc
     }
 
-    /// A single-entry zip holding `contents` uncompressed under `name`.
-    fn stored_zip(name: &str, contents: &[u8]) -> Vec<u8> {
-        let name = name.as_bytes();
-        let crc = crc32(contents).to_le_bytes();
-        let size = (contents.len() as u32).to_le_bytes();
-        let name_len = (name.len() as u16).to_le_bytes();
-
+    /// A zip holding each entry uncompressed. Names may contain `/`, which the
+    /// extraction command turns into directories.
+    fn stored_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
         let mut zip = Vec::new();
-        zip.extend_from_slice(b"PK\x03\x04"); // local file header
-        zip.extend_from_slice(&[20, 0]); // version needed
-        zip.extend_from_slice(&[0, 0]); // flags
-        zip.extend_from_slice(&[0, 0]); // method 0: stored
-        zip.extend_from_slice(&[0, 0, 0, 0]); // mtime, mdate
-        zip.extend_from_slice(&crc);
-        zip.extend_from_slice(&size); // compressed size
-        zip.extend_from_slice(&size); // uncompressed size
-        zip.extend_from_slice(&name_len);
-        zip.extend_from_slice(&[0, 0]); // extra length
-        zip.extend_from_slice(name);
-        zip.extend_from_slice(contents);
+        let mut central = Vec::new();
+
+        for (name, contents) in entries {
+            let name = name.as_bytes();
+            let crc = crc32(contents).to_le_bytes();
+            let size = (contents.len() as u32).to_le_bytes();
+            let name_len = (name.len() as u16).to_le_bytes();
+            let offset = (zip.len() as u32).to_le_bytes();
+
+            zip.extend_from_slice(b"PK\x03\x04"); // local file header
+            zip.extend_from_slice(&[20, 0]); // version needed
+            zip.extend_from_slice(&[0, 0]); // flags
+            zip.extend_from_slice(&[0, 0]); // method 0: stored
+            zip.extend_from_slice(&[0, 0, 0, 0]); // mtime, mdate
+            zip.extend_from_slice(&crc);
+            zip.extend_from_slice(&size); // compressed size
+            zip.extend_from_slice(&size); // uncompressed size
+            zip.extend_from_slice(&name_len);
+            zip.extend_from_slice(&[0, 0]); // extra length
+            zip.extend_from_slice(name);
+            zip.extend_from_slice(contents);
+
+            central.extend_from_slice(b"PK\x01\x02"); // central directory header
+            central.extend_from_slice(&[20, 0]); // version made by
+            central.extend_from_slice(&[20, 0]); // version needed
+            central.extend_from_slice(&[0, 0]); // flags
+            central.extend_from_slice(&[0, 0]); // method
+            central.extend_from_slice(&[0, 0, 0, 0]); // mtime, mdate
+            central.extend_from_slice(&crc);
+            central.extend_from_slice(&size);
+            central.extend_from_slice(&size);
+            central.extend_from_slice(&name_len);
+            central.extend_from_slice(&[0, 0]); // extra length
+            central.extend_from_slice(&[0, 0]); // comment length
+            central.extend_from_slice(&[0, 0]); // disk number
+            central.extend_from_slice(&[0, 0]); // internal attributes
+            central.extend_from_slice(&[0, 0, 0, 0]); // external attributes
+            central.extend_from_slice(&offset);
+            central.extend_from_slice(name);
+        }
 
         let central_offset = (zip.len() as u32).to_le_bytes();
-
-        let mut central = Vec::new();
-        central.extend_from_slice(b"PK\x01\x02"); // central directory header
-        central.extend_from_slice(&[20, 0]); // version made by
-        central.extend_from_slice(&[20, 0]); // version needed
-        central.extend_from_slice(&[0, 0]); // flags
-        central.extend_from_slice(&[0, 0]); // method
-        central.extend_from_slice(&[0, 0, 0, 0]); // mtime, mdate
-        central.extend_from_slice(&crc);
-        central.extend_from_slice(&size);
-        central.extend_from_slice(&size);
-        central.extend_from_slice(&name_len);
-        central.extend_from_slice(&[0, 0]); // extra length
-        central.extend_from_slice(&[0, 0]); // comment length
-        central.extend_from_slice(&[0, 0]); // disk number
-        central.extend_from_slice(&[0, 0]); // internal attributes
-        central.extend_from_slice(&[0, 0, 0, 0]); // external attributes
-        central.extend_from_slice(&0u32.to_le_bytes()); // local header offset
-        central.extend_from_slice(name);
-
         let central_len = (central.len() as u32).to_le_bytes();
+        let count = (entries.len() as u16).to_le_bytes();
 
         zip.extend_from_slice(&central);
         zip.extend_from_slice(b"PK\x05\x06"); // end of central directory
         zip.extend_from_slice(&[0, 0]); // this disk
         zip.extend_from_slice(&[0, 0]); // disk holding the central directory
-        zip.extend_from_slice(&[1, 0]); // entries on this disk
-        zip.extend_from_slice(&[1, 0]); // entries in total
+        zip.extend_from_slice(&count); // entries on this disk
+        zip.extend_from_slice(&count); // entries in total
         zip.extend_from_slice(&central_len);
         zip.extend_from_slice(&central_offset);
         zip.extend_from_slice(&[0, 0]); // comment length
@@ -195,29 +296,28 @@ mod tests {
 
     /// An artifact directory holding nothing but `artifact.zip` -- the state a
     /// failed extraction leaves behind.
-    fn artifact_dir(contents: &[u8]) -> tempfile::TempDir {
+    fn artifact_dir(entries: &[(&str, &[u8])]) -> tempfile::TempDir {
         let dir = tempfile::tempdir().expect("Failed to create a temporary directory");
 
-        std::fs::write(
-            dir.path().join("artifact.zip"),
-            stored_zip("compactc", contents),
-        )
-        .expect("Failed to write artifact.zip");
+        std::fs::write(dir.path().join("artifact.zip"), stored_zip(entries))
+            .expect("Failed to write artifact.zip");
 
         dir
     }
 
+    fn zip_in(dir: &Path) -> std::path::PathBuf {
+        dir.join("artifact.zip")
+    }
+
+    const COMPILER: &[(&str, &[u8])] = &[("compactc", b"binary")];
+
     #[tokio::test]
     async fn extracts_the_compiler_from_the_archive() {
-        let dir = artifact_dir(b"binary");
+        let dir = artifact_dir(COMPILER);
 
-        extract_archive(
-            EXTRACTION_COMMAND,
-            dir.path(),
-            &dir.path().join("artifact.zip"),
-        )
-        .await
-        .expect("Extraction should succeed");
+        extract_archive(EXTRACTION_COMMAND, dir.path(), &zip_in(dir.path()))
+            .await
+            .expect("Extraction should succeed");
 
         assert_eq!(
             std::fs::read(dir.path().join("compactc")).expect("Failed to read compactc"),
@@ -230,19 +330,15 @@ mod tests {
     /// standard input is closed, so a prompt fails the retry.
     #[tokio::test]
     async fn re_extraction_overwrites_a_partial_result() {
-        let dir = artifact_dir(b"binary");
+        let dir = artifact_dir(COMPILER);
 
         // a truncated leftover from an interrupted extraction
         std::fs::write(dir.path().join("compactc"), b"trunc")
             .expect("Failed to write the partial file");
 
-        extract_archive(
-            EXTRACTION_COMMAND,
-            dir.path(),
-            &dir.path().join("artifact.zip"),
-        )
-        .await
-        .expect("Re-extraction should overwrite rather than prompt");
+        extract_archive(EXTRACTION_COMMAND, dir.path(), &zip_in(dir.path()))
+            .await
+            .expect("Re-extraction should overwrite rather than prompt");
 
         assert_eq!(
             std::fs::read(dir.path().join("compactc")).expect("Failed to read compactc"),
@@ -255,10 +351,10 @@ mod tests {
     /// error has to name the command and say what to do about it.
     #[tokio::test]
     async fn a_missing_extraction_command_is_named() {
-        let dir = artifact_dir(b"binary");
+        let dir = artifact_dir(COMPILER);
         let missing = "compact-test-no-such-extraction-command";
 
-        let error = extract_archive(missing, dir.path(), &dir.path().join("artifact.zip"))
+        let error = extract_archive(missing, dir.path(), &zip_in(dir.path()))
             .await
             .expect_err("A missing extraction command must fail");
 
@@ -271,6 +367,119 @@ mod tests {
         assert!(
             message.contains("PATH"),
             "the error should say where the command is looked for: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn installs_every_entry_and_clears_the_staging_directory() {
+        let entries: &[(&str, &[u8])] = &[
+            ("compactc", b"compiler"),
+            ("format-compact", b"formatter"),
+            ("lib/helper", b"library"),
+        ];
+        let dir = artifact_dir(entries);
+
+        install_archive(EXTRACTION_COMMAND, dir.path(), &zip_in(dir.path()))
+            .await
+            .expect("Installation should succeed");
+
+        assert_eq!(
+            std::fs::read(dir.path().join("compactc")).expect("compactc"),
+            b"compiler"
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join("format-compact")).expect("format-compact"),
+            b"formatter"
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join("lib").join("helper")).expect("lib/helper"),
+            b"library"
+        );
+        assert!(
+            !dir.path().join(".incoming").exists(),
+            "the staging directory should not survive a successful installation"
+        );
+    }
+
+    /// Issue #739, one level down: callers treat the presence of `compactc' as
+    /// proof that a version is installed, so an extraction that fails partway
+    /// must not leave that file behind. Unpacking straight into the version
+    /// directory did exactly that whenever the failure came after the compiler
+    /// binary had been written -- a full disk, a killed process, a corrupt
+    /// archive -- and the next run then reported "already installed" over a
+    /// broken installation.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_extraction_that_fails_after_writing_the_compiler_installs_nothing() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = artifact_dir(COMPILER);
+
+        // stands in for an extraction that reaches the compiler binary and then
+        // dies; it runs in the directory it is told to unpack into
+        let script = dir.path().join("half-extract");
+        std::fs::write(&script, "#!/bin/sh\nprintf partial > compactc\nexit 1\n")
+            .expect("Failed to write the stub");
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
+            .expect("Failed to make the stub executable");
+
+        install_archive(
+            script.to_str().expect("stub path"),
+            dir.path(),
+            &zip_in(dir.path()),
+        )
+        .await
+        .expect_err("A failed extraction must fail the installation");
+
+        assert!(
+            !dir.path().join("compactc").exists(),
+            "a failed installation must not leave something that looks installed"
+        );
+    }
+
+    #[tokio::test]
+    async fn leftovers_from_an_interrupted_attempt_are_discarded() {
+        let dir = artifact_dir(COMPILER);
+
+        let staging = dir.path().join(".incoming");
+        std::fs::create_dir_all(&staging).expect("staging");
+        std::fs::write(staging.join("compactc"), b"stale").expect("stale compiler");
+        std::fs::write(staging.join("junk"), b"junk").expect("junk");
+
+        install_archive(EXTRACTION_COMMAND, dir.path(), &zip_in(dir.path()))
+            .await
+            .expect("Installation should succeed");
+
+        assert_eq!(
+            std::fs::read(dir.path().join("compactc")).expect("compactc"),
+            b"binary"
+        );
+        assert!(
+            !dir.path().join("junk").exists(),
+            "leftovers from the interrupted attempt should not be installed"
+        );
+    }
+
+    #[tokio::test]
+    async fn installing_replaces_a_directory_that_is_already_there() {
+        let entries: &[(&str, &[u8])] = &[("compactc", b"binary"), ("lib/helper", b"new")];
+        let dir = artifact_dir(entries);
+
+        let lib = dir.path().join("lib");
+        std::fs::create_dir_all(&lib).expect("lib");
+        std::fs::write(lib.join("stale"), b"stale").expect("stale");
+
+        install_archive(EXTRACTION_COMMAND, dir.path(), &zip_in(dir.path()))
+            .await
+            .expect("Installation should succeed");
+
+        assert_eq!(
+            std::fs::read(lib.join("helper")).expect("lib/helper"),
+            b"new"
+        );
+        assert!(
+            !lib.join("stale").exists(),
+            "a replaced directory should not keep its old contents"
         );
     }
 }

--- a/tools/compact/src/lib.rs
+++ b/tools/compact/src/lib.rs
@@ -34,6 +34,7 @@ pub use self::{
     },
     compact_directory::CompactDirectory,
     compiler::Compiler,
+    compiler_legacy::{CompilerAsset, is_corrupt_archive},
 };
 use semver::Version;
 use std::sync::LazyLock;

--- a/tools/compact/src/utils.rs
+++ b/tools/compact/src/utils.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 use crate::{CommandLineArguments, Target, compiler::Compiler};
-use anyhow::{Context, Result, anyhow, ensure};
+use anyhow::{Context, Result, anyhow, bail, ensure};
 use semver::Version;
 use tokio::fs;
 
@@ -166,7 +166,28 @@ pub async fn get_current_compiler(cfg: &CommandLineArguments) -> Result<Option<C
 
     let file = match fs::read_link(&bin).await {
         Ok(file) => {
-            ensure!(file.is_file(), "Expecting a file: `{file:?}'");
+            // An installation interrupted before the compiler was in place used
+            // to leave this link pointing at a file that was never written, and
+            // then every command that resolves the default compiler failed with
+            // a bare `Expecting a file', which names no way out. `compact
+            // update' does repair it, so say which command to run.
+            if !file.is_file() {
+                let command = match file
+                    .parent()
+                    .and_then(Path::parent)
+                    .and_then(Path::file_name)
+                    .map(|version| version.to_string_lossy().into_owned())
+                {
+                    Some(version) => format!("compact update {version}"),
+                    None => "compact update".to_owned(),
+                };
+
+                bail!(
+                    "The default compiler is missing: `{bin:?}' points at `{file:?}', \
+                     which does not exist. Run `{command}' to reinstall it."
+                );
+            }
+
             file
         }
         Err(error) if error.kind() == ErrorKind::NotFound => {

--- a/tools/compact/src/utils.rs
+++ b/tools/compact/src/utils.rs
@@ -81,6 +81,20 @@ pub async fn set_current_compiler(
 ) -> Result<Compiler> {
     // set compactc
     let source = compiler.path_compactc().to_path_buf();
+
+    // `fs::symlink' will happily point at a path that does not exist, and the
+    // validation below only runs once every link has been written. Linking an
+    // absent binary therefore leaves a dangling `<compact dir>/bin/compactc',
+    // which makes every later `check', `list --installed' and `compile' fail
+    // too. Refuse up front so one bad install cannot break the others.
+    let version = compiler.version();
+    ensure!(
+        source.is_file(),
+        "Refusing to set the default compiler: no compiler binary at `{source:?}'. \
+         The {version} installation is incomplete; run `compact update {version}' \
+         again to repair it."
+    );
+
     let target = cfg.directory.bin_dir().join("compactc");
 
     if target.is_symlink() {

--- a/tools/compact/src/utils.rs
+++ b/tools/compact/src/utils.rs
@@ -42,7 +42,7 @@ pub async fn read_parent_name_from_link(path: &PathBuf) -> Option<(PathBuf, Stri
     })
 }
 
-pub async fn remove_file_if_exists(path: &PathBuf) -> Result<()> {
+pub async fn remove_file_if_exists(path: &Path) -> Result<()> {
     if path.try_exists().context("Checking if path exists")? {
         tokio::fs::remove_file(path)
             .await

--- a/tools/compact/tests/common/mod.rs
+++ b/tools/compact/tests/common/mod.rs
@@ -116,6 +116,14 @@ pub fn assert_command_output(
 
     let mut cmd = Command::new(binary);
 
+    // Clap wraps help to the terminal width. Under test there is no terminal,
+    // so it falls back to 100 columns, which makes the expected output depend
+    // on the length of `$HOME' and of the temporary directory path -- a test
+    // that passes in CI fails for a developer whose home or TMPDIR is longer.
+    // Ask for a width nothing wraps at, so help output is a function of its
+    // content alone. Set before the caller's variables so a test can override.
+    cmd.env("COLUMNS", "10000");
+
     if let Some(vars) = env {
         for (k, v) in vars {
             cmd.env(k, v);
@@ -156,6 +164,14 @@ pub fn assert_command_output_sorted(
     let binary = binary_path.unwrap_or("../../target/debug/compact");
 
     let mut cmd = Command::new(binary);
+
+    // Clap wraps help to the terminal width. Under test there is no terminal,
+    // so it falls back to 100 columns, which makes the expected output depend
+    // on the length of `$HOME' and of the temporary directory path -- a test
+    // that passes in CI fails for a developer whose home or TMPDIR is longer.
+    // Ask for a width nothing wraps at, so help output is a function of its
+    // content alone. Set before the caller's variables so a test can override.
+    cmd.env("COLUMNS", "10000");
 
     if let Some(vars) = env {
         for (k, v) in vars {

--- a/tools/compact/tests/common/mod.rs
+++ b/tools/compact/tests/common/mod.rs
@@ -61,6 +61,45 @@ pub fn load_and_replace<P: AsRef<Path>>(path: P, replacements: &[(&str, &str)]) 
     result
 }
 
+/// Clap's exit code for an argument-parsing failure.
+#[allow(dead_code)]
+const USAGE_ERROR: i32 = 2;
+
+/// Fail loudly rather than let a test operate on the developer's real
+/// `~/.compact`.
+///
+/// Tests used to invoke stateful subcommands with no directory argument, so
+/// `cargo test` ran `clean` against the caller's own installation and deleted
+/// their compilers -- the tests were named `*_nothing_installed' because
+/// whoever wrote them had nothing installed.
+///
+/// An invocation is exempt only when it cannot reach a command handler: a
+/// `--help'/`--version' query, which clap answers and exits, or one the test
+/// expects clap to reject outright (`USAGE_ERROR'). Everything else has to name
+/// a directory.
+#[allow(dead_code)]
+fn assert_directory_is_isolated(
+    args: &[&str],
+    env: Option<&HashMap<String, String>>,
+    expected_exit_code: i32,
+) {
+    // `help' is clap's built-in subcommand, answered and exited like the flags.
+    const HELP_OR_VERSION: [&str; 5] = ["--help", "-h", "--version", "-V", "help"];
+
+    if expected_exit_code == USAGE_ERROR || args.iter().any(|arg| HELP_OR_VERSION.contains(arg)) {
+        return;
+    }
+
+    assert!(
+        args.contains(&"--directory")
+            || env.is_some_and(|env| env.contains_key("COMPACT_DIRECTORY")),
+        "`compact {}' was invoked with neither --directory nor COMPACT_DIRECTORY. \
+         It would act on the real ~/.compact and can delete the caller's installed \
+         compilers. Pass --directory with a tempfile::tempdir() path.",
+        args.join(" ")
+    );
+}
+
 // probably need to rework it one day - normal assert
 #[allow(dead_code)]
 pub fn assert_command_output(
@@ -71,6 +110,8 @@ pub fn assert_command_output(
     expected_stderr: &str,
     expected_exit_code: i32,
 ) {
+    assert_directory_is_isolated(args, env.as_ref(), expected_exit_code);
+
     let binary = binary_path.unwrap_or("../../target/debug/compact");
 
     let mut cmd = Command::new(binary);
@@ -110,6 +151,8 @@ pub fn assert_command_output_sorted(
     expected_stderr: &str,
     expected_exit_code: i32,
 ) {
+    assert_directory_is_isolated(args, env.as_ref(), expected_exit_code);
+
     let binary = binary_path.unwrap_or("../../target/debug/compact");
 
     let mut cmd = Command::new(binary);

--- a/tools/compact/tests/test_check.rs
+++ b/tools/compact/tests/test_check.rs
@@ -20,8 +20,11 @@ mod common;
 
 #[test]
 fn test_compact_check_no_param() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path();
+
     run_command(
-        &["check"],
+        &["--directory", &format!("{}", temp_path.display()), "check"],
         None,
         Some("./output/check/std_default.txt"),
         None,

--- a/tools/compact/tests/test_clean.rs
+++ b/tools/compact/tests/test_clean.rs
@@ -20,8 +20,11 @@ mod common;
 
 #[test]
 fn test_compact_clean_nothing_installed() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path();
+
     run_command(
-        &["clean"],
+        &["--directory", &format!("{}", temp_path.display()), "clean"],
         None,
         Some("./output/clean/std_default.txt"),
         None,
@@ -44,8 +47,16 @@ fn test_compact_clean_invalid_version() {
 
 #[test]
 fn test_compact_clean_keep_nothing_installed() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path();
+
     run_command(
-        &["clean", "--keep-current"],
+        &[
+            "--directory",
+            &format!("{}", temp_path.display()),
+            "clean",
+            "--keep-current",
+        ],
         None,
         Some("./output/clean/std_default.txt"),
         None,

--- a/tools/compact/tests/test_compile.rs
+++ b/tools/compact/tests/test_compile.rs
@@ -20,8 +20,15 @@ mod common;
 
 #[test]
 fn test_compact_compile_no_param() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path();
+
     run_command(
-        &["compile"],
+        &[
+            "--directory",
+            &format!("{}", temp_path.display()),
+            "compile",
+        ],
         None,
         None,
         Some("./output/compile/err_default.txt"),
@@ -97,8 +104,16 @@ fn test_compile_contract_no_compiler_installed() {
 
 #[test]
 fn test_compact_compile_invalid_param() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path();
+
     run_command(
-        &["compile", "latest"],
+        &[
+            "--directory",
+            &format!("{}", temp_path.display()),
+            "compile",
+            "latest",
+        ],
         None,
         None,
         Some("./output/compile/err_default.txt"),

--- a/tools/compact/tests/test_list.rs
+++ b/tools/compact/tests/test_list.rs
@@ -15,9 +15,10 @@
 
 use crate::common::{
     COMPACT_VERSION, LATEST_COMPACTC_VERSION, OLDEST_COMPACTC_VERSION, PREVIOUS_COMPACTC_VERSION,
-    run_command,
+    get_version, run_command,
 };
 use std::env;
+use std::fs;
 
 mod common;
 
@@ -132,5 +133,46 @@ fn test_compact_list_param_v() {
         None,
         &[("[COMPACT_VERSION]", COMPACT_VERSION)],
         Some(0),
+    );
+}
+
+/// Issue #739: an installation interrupted before the compiler was in place
+/// left the default-compiler link pointing at a file that was never written,
+/// and every command that resolves it then failed with a bare
+/// `Expecting a file'. `compact update' repairs it, so the error has to say so
+/// rather than leaving the user to work it out.
+#[cfg(unix)]
+#[test]
+fn test_compact_list_installed_dangling_default() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path();
+    let directory = format!("{}", temp_path.display());
+
+    let installed = temp_path
+        .join("versions")
+        .join(LATEST_COMPACTC_VERSION)
+        .join(get_version());
+    fs::create_dir_all(&installed).unwrap();
+    fs::create_dir_all(temp_path.join("bin")).unwrap();
+
+    // the link the old code left behind: created before it was validated, and
+    // pointing at a compiler that never arrived
+    std::os::unix::fs::symlink(
+        installed.join("compactc"),
+        temp_path.join("bin").join("compactc"),
+    )
+    .unwrap();
+
+    run_command(
+        &["--directory", &directory, "list", "--installed"],
+        None,
+        None,
+        Some("./output/list/err_dangling_default.txt"),
+        &[
+            ("[COMPACT_DIR]", &directory),
+            ("[COMPACTC_VERSION]", LATEST_COMPACTC_VERSION),
+            ("[SYSTEM_VERSION]", get_version()),
+        ],
+        Some(1),
     );
 }

--- a/tools/compact/tests/test_list.rs
+++ b/tools/compact/tests/test_list.rs
@@ -24,7 +24,11 @@ mod common;
 #[test]
 fn test_compact_list_no_param() {
     run_command(
-        &["list"],
+        &[
+            "--directory",
+            &format!("{}", tempfile::tempdir().unwrap().path().display()),
+            "list",
+        ],
         None,
         Some("./output/list/std_default.txt"),
         None,
@@ -40,7 +44,12 @@ fn test_compact_list_no_param() {
 #[test]
 fn test_compact_list_param_i_nothing_installed() {
     run_command(
-        &["list", "-i"],
+        &[
+            "--directory",
+            &format!("{}", tempfile::tempdir().unwrap().path().display()),
+            "list",
+            "-i",
+        ],
         None,
         Some("./output/list/std_list_installed.txt"),
         None,
@@ -52,7 +61,12 @@ fn test_compact_list_param_i_nothing_installed() {
 #[test]
 fn test_compact_list_param_installed_nothing_installed() {
     run_command(
-        &["list", "--installed"],
+        &[
+            "--directory",
+            &format!("{}", tempfile::tempdir().unwrap().path().display()),
+            "list",
+            "--installed",
+        ],
         None,
         Some("./output/list/std_list_installed.txt"),
         None,

--- a/tools/compact/tests/test_scenarios_two.rs
+++ b/tools/compact/tests/test_scenarios_two.rs
@@ -74,7 +74,7 @@ fn test_sc10_update_two_versions_compile_contract_with_previous() {
 
     let temp_output = tempfile::tempdir().unwrap();
     let temp_output_path = temp_output.path();
-    let compiler = &format!("+{}", PREVIOUS_COMPACTC_VERSION);
+    let compiler = &format!("+{PREVIOUS_COMPACTC_VERSION}");
 
     run_command(
         &[

--- a/tools/compact/tests/test_self.rs
+++ b/tools/compact/tests/test_self.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use crate::common::{COMPACT_VERSION, run_command};
+use std::collections::HashMap;
 use std::env;
 
 mod common;
@@ -38,6 +39,15 @@ fn test_compact_self_check() {
     let temp_dir = tempfile::tempdir().unwrap();
     let temp_path = temp_dir.path();
 
+    // `self check' and `self update' load the install receipt written by the
+    // official installer. A developer who installed `compact' that way has one,
+    // so the receipt is found, the command succeeds, and the expected failure
+    // never happens -- these two tests only passed on a machine that had never
+    // installed the tool. `AXOUPDATER_CONFIG_PATH' short-circuits the receipt
+    // search ahead of `XDG_CONFIG_HOME' and the home directory, so pointing it
+    // at an empty directory makes "no receipt" true by construction.
+    let receipt_dir = tempfile::tempdir().unwrap();
+
     run_command(
         &[
             "--directory",
@@ -45,7 +55,10 @@ fn test_compact_self_check() {
             "self",
             "check",
         ],
-        None,
+        Some(HashMap::from([(
+            "AXOUPDATER_CONFIG_PATH".to_string(),
+            receipt_dir.path().display().to_string(),
+        )])),
         None,
         Some("./output/self/err_no_releases.txt"),
         &[],
@@ -58,6 +71,15 @@ fn test_compact_self_update() {
     let temp_dir = tempfile::tempdir().unwrap();
     let temp_path = temp_dir.path();
 
+    // `self check' and `self update' load the install receipt written by the
+    // official installer. A developer who installed `compact' that way has one,
+    // so the receipt is found, the command succeeds, and the expected failure
+    // never happens -- these two tests only passed on a machine that had never
+    // installed the tool. `AXOUPDATER_CONFIG_PATH' short-circuits the receipt
+    // search ahead of `XDG_CONFIG_HOME' and the home directory, so pointing it
+    // at an empty directory makes "no receipt" true by construction.
+    let receipt_dir = tempfile::tempdir().unwrap();
+
     run_command(
         &[
             "--directory",
@@ -65,7 +87,10 @@ fn test_compact_self_update() {
             "self",
             "update",
         ],
-        None,
+        Some(HashMap::from([(
+            "AXOUPDATER_CONFIG_PATH".to_string(),
+            receipt_dir.path().display().to_string(),
+        )])),
         None,
         Some("./output/self/err_no_releases.txt"),
         &[],

--- a/tools/compact/tests/test_update.rs
+++ b/tools/compact/tests/test_update.rs
@@ -288,3 +288,63 @@ fn test_compact_update_repairs_incomplete_installation() {
         "the default compiler symlink should resolve to a real file"
     );
 }
+
+/// Issue #739, last corner: the archive is only downloaded when it is not
+/// already on disk, so an archive that is complete but unreadable -- a bad
+/// checksum, a stitched resume -- made every retry fail in exactly the same
+/// way, with deleting it by hand the only way forward. That is the shape of the
+/// original report. An unreadable archive is now discarded and fetched again.
+#[test]
+fn test_compact_update_repairs_a_corrupt_archive() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path();
+    let directory = format!("{}", temp_path.display());
+
+    run_command(
+        &["--directory", &directory, "update", LATEST_COMPACTC_VERSION],
+        None,
+        Some("./output/update/std_update_other.txt"),
+        None,
+        &[
+            ("[COMPACTC_VERSION]", LATEST_COMPACTC_VERSION),
+            ("[SYSTEM_VERSION]", get_version()),
+        ],
+        None,
+    );
+
+    let artifact_dir = temp_path
+        .join("versions")
+        .join(LATEST_COMPACTC_VERSION)
+        .join(get_version());
+
+    // Poison the archive and remove what it produced, so the retry has to read
+    // the archive rather than trust the directory.
+    fs::write(
+        artifact_dir.join("artifact.zip"),
+        b"not an archive any more",
+    )
+    .unwrap();
+    fs::remove_file(artifact_dir.join("compactc")).unwrap();
+    fs::remove_file(temp_path.join("bin").join("compactc")).unwrap();
+
+    run_command(
+        &["--directory", &directory, "update", LATEST_COMPACTC_VERSION],
+        None,
+        Some("./output/update/std_repair_corrupt_archive.txt"),
+        None,
+        &[
+            ("[COMPACTC_VERSION]", LATEST_COMPACTC_VERSION),
+            ("[SYSTEM_VERSION]", get_version()),
+        ],
+        None,
+    );
+
+    assert!(
+        artifact_dir.join("compactc").is_file(),
+        "the compiler should have been reinstalled from a freshly fetched archive"
+    );
+    assert!(
+        temp_path.join("bin").join("compactc").is_file(),
+        "the default compiler symlink should resolve to a real file"
+    );
+}

--- a/tools/compact/tests/test_update.rs
+++ b/tools/compact/tests/test_update.rs
@@ -18,6 +18,7 @@ use crate::common::{
 };
 use std::collections::HashMap;
 use std::env;
+use std::fs;
 
 mod common;
 
@@ -206,4 +207,84 @@ fn test_compact_update_env_dir() {
     );
 
     assert_path_contains_string(temp_path_env, &[LATEST_COMPACTC_VERSION, get_version()]);
+}
+
+/// Issue #739: an extraction that fails leaves the version directory in place
+/// holding nothing but `artifact.zip'. A retry used to see that directory,
+/// report "already installed", skip re-extraction and then fail on the missing
+/// binary -- and because the default symlink was written before it was
+/// validated, it left a dangling `bin/compactc' that broke every later command
+/// too. A retry has to re-extract and end up with a compiler that resolves.
+#[test]
+fn test_compact_update_repairs_incomplete_installation() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path();
+    let directory = format!("{}", temp_path.display());
+
+    run_command(
+        &["--directory", &directory, "update", LATEST_COMPACTC_VERSION],
+        None,
+        Some("./output/update/std_update_other.txt"),
+        None,
+        &[
+            ("[COMPACTC_VERSION]", LATEST_COMPACTC_VERSION),
+            ("[SYSTEM_VERSION]", get_version()),
+        ],
+        None,
+    );
+
+    // Reproduce what a failed extraction leaves behind: the downloaded archive
+    // and nothing else.
+    let artifact_dir = temp_path
+        .join("versions")
+        .join(LATEST_COMPACTC_VERSION)
+        .join(get_version());
+
+    for entry in fs::read_dir(&artifact_dir).unwrap() {
+        let path = entry.unwrap().path();
+
+        if path.file_name().unwrap() == "artifact.zip" {
+            continue;
+        }
+
+        if path.is_dir() {
+            fs::remove_dir_all(&path).unwrap();
+        } else {
+            fs::remove_file(&path).unwrap();
+        }
+    }
+
+    fs::remove_file(temp_path.join("bin").join("compactc")).unwrap();
+
+    assert!(
+        artifact_dir.join("artifact.zip").is_file(),
+        "the archive should survive a failed extraction"
+    );
+    assert!(
+        !artifact_dir.join("compactc").exists(),
+        "a failed extraction leaves no compiler behind"
+    );
+
+    run_command(
+        &["--directory", &directory, "update", LATEST_COMPACTC_VERSION],
+        None,
+        Some("./output/update/std_reinstall_incomplete.txt"),
+        None,
+        &[
+            ("[COMPACTC_VERSION]", LATEST_COMPACTC_VERSION),
+            ("[SYSTEM_VERSION]", get_version()),
+        ],
+        None,
+    );
+
+    assert!(
+        artifact_dir.join("compactc").is_file(),
+        "the retry should have re-extracted the compiler"
+    );
+
+    // `is_file' follows the link, so this also rules out a dangling symlink.
+    assert!(
+        temp_path.join("bin").join("compactc").is_file(),
+        "the default compiler symlink should resolve to a real file"
+    );
 }


### PR DESCRIPTION
Fixes #739.
 
## The bug
 
On a machine without `unzip`, `compact update 0.31.1` fails to extract. Installing `unzip` and running it again does not help: the retry reports `already installed`, skips extraction, and dies with `Expecting a file: '.../compactc'`. The only way out is `rm -rf ~/.compact/versions/0.31.1`.
 
The exact-version fast path tested whether the *version directory* existed. A failed extraction leaves that directory holding nothing but `artifact.zip`, so the retry saw a directory, called it installed, and never looked for a compiler.
 
It is worse than reported. `set_current_compiler` wrote the default-compiler symlink **before** validating it, and `fs::symlink` will happily point at a path that does not exist. So the failed retry left a dangling `~/.compact/bin/compactc`, and from then on `compact check`, `compact list --installed` and `compact compile` all failed the same way. One incomplete install broke the whole installation.
 
## What changed
 
**The reported defect**
 
- The fast path requires `compactc`, not just its directory, and says so when it is repairing a previous attempt.
- `set_current_compiler` refuses to link a compiler binary that is not there, so a failure can no longer poison the other commands.
- A default compiler that is already dangling now reports the remedy — `Run 'compact update 0.31.1' to reinstall it` — rather than a bare `Expecting a file`. Upgrading alone does not repair an installation that is already broken, so the people who hit this need to be told what to run.

**Presence is not validity**
 
Requiring `compactc` rather than the directory moves the check one level down; it does not make it a completeness check. An extraction that failed *after* writing that one file still left something that looked installed:
 
```
$ compact update 0.31.1        # 27-byte compactc, extraction never finished
compact: x86_64-unknown-linux-musl -- 0.31.1 -- already installed
compact: x86_64-unknown-linux-musl -- 0.31.1 -- default.
$ compact compile --version
Error: Failed to run compactc
```
 
Archives are now unpacked into a staging directory inside the version directory and moved into place with the compiler binary **last**. `rename` is atomic within a filesystem and staging is a child of the destination, so `compactc` appears only once everything else is already there, and a failure anywhere leaves the directory without it — which the fast path treats as "not installed" and retries.
 
**No more external `unzip`**
 
The reporter's machine had `curl`, `tar`, `xz`, `zstd` and `gzip` but not `unzip`, which is a separate package that nothing else pulls in. Naming the missing command made the failure legible; it did not make the machine work. The archive is now read in-process with the `zip` crate.
 
- `default-features = false, features = ["deflate-flate2"]` — the launcher never writes an archive, so it needs neither a compressor nor a second inflate backend.
- Three new packages (`zip`, `arbitrary`, `derive_arbitrary`); `flate2` and `miniz_oxide` were already present via reqwest. Nothing binds to C, which matters for the musl cross-builds.
- The release archive is built by `zip --junk-paths`, so it is a flat set of regular files. Entries are written by file name alone, which also means a hand-made archive cannot direct a write outside the destination.
- `unzip` restored each entry's recorded mode and nothing does that for us now, so the mode is applied explicitly — a `compactc` without its executable bit is an installation that looks complete and cannot run.
**Corrupt archives repair themselves**
 
The archive is downloaded only when it is not already on disk, so a complete-but-unreadable one failed every retry identically. Failures are now classified: an unreadable zip, an undecompressable entry, or a write failing with `InvalidData` (how a checksum mismatch surfaces) is the archive's fault, and the archive is discarded and fetched once more. A full disk or a permission error propagates untouched — fetching the file again would not fix it, and discarding a good archive would throw away the whole download.
 
## Test-suite repairs, and one warning
 
**Before this branch, `cargo test` deleted your installed compilers.** `test_clean.rs` ran `clean` and `clean --keep-current` with no `--directory`, so they operated on the real `~/.compact`. They are named `*_nothing_installed` because whoever wrote them had nothing installed. Running the suite removed 0.27.0, 0.29.0 and 0.30.0 from a maintainer's machine while preparing this PR. Eight tests in total read or wrote the real installation; all are now isolated.
 
Four more expectations passed in CI and failed for real developers — CI green was actively misleading about whether this suite works:
 
| expectation | depended on |
|---|---|
| `test_compact_check_no_param` | whether you had compilers installed |
| help output | the length of `$HOME` and `$TMPDIR`, and terminal width |
| version lists | the published channel, last refreshed at 0.31.1 |
| `test_compact_self_check` / `_update` | whether you had ever installed `compact` |
 
Fixed by isolating the compact directory, pinning `COLUMNS` in the harness so help is a function of its content alone, refreshing the constants to 0.34.0/0.31.1, and pinning `AXOUPDATER_CONFIG_PATH` so "no install receipt" is true by construction.
 
`output/compile/compact_help.txt` is a copy of *compactc's* help text, so it drifts whenever `LATEST_COMPACTC_VERSION` moves; 0.34.0 documents `--feature-zkir-v3`.
 
## Toolchain and CI
 
- `rust-toolchain.toml` pins the MSRV already declared in `Cargo.toml`. `cargo clippy -- -D warnings` passed or failed depending on which clippy happened to be installed — 1.88 reported three `uninlined_format_args` failures that 1.95 did not — because `compact-test.yml` asks for `stable`, making the result a function of the calendar. Cargo's feature resolution is version-dependent too, which is how `clap`'s `wrap_help` came to be enabled by accident (below).
- `clap`'s `wrap_help` is now requested explicitly. It had been arriving only through feature unification with the `cargo-nextest` dev-dependency, so wrapped help appeared under `cargo test` while the installed binary printed one long line — the expected-output files recorded output no user had ever seen. **This changes `compact --help` for users**: it now wraps to the terminal.
- Dropped `cargo-nextest` from dev-dependencies. A dev-dependency is a library to link, not a tool to run, so it never put `cargo nextest` on anyone's PATH; CI installs the binary through `taiki-e/install-action`. It did pull nextest's tree into every test and `--all-targets` build. **The lockfile goes from 490 packages to 310.**
- Dropped `pretty_assertions`, which was listed in both `[dependencies]` and `[dev-dependencies]` and imported nowhere; the first copy linked a test-output crate into the shipped binary.
- The cargo caches hashed `tools/compact/Cargo.lock` and cached `tools/compact/target`. Neither path exists — `tools/compact` is a workspace member — so `hashFiles` matched nothing, the keys were constant and never invalidated when dependencies changed, and the target cache archived an empty directory.
## Testing
 
`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` and the full suite pass, including the network-dependent tests against the live GitHub API.
 
New coverage is 15 unit tests on extraction and installation plus 3 integration tests. The ones carrying real weight were checked by breaking the code and confirming the right test failed:
 
- removing the mode restoration → `the_extracted_compiler_is_executable`
- removing the staging step → `a_failed_installation_leaves_no_compiler_in_place`
- accepting an entry name that escapes the archive → `an_entry_whose_name_escapes_the_archive_is_refused`
- removing the deflate feature → `extracts_a_deflated_archive`
- blaming every failure on the archive, or none → the classification tests, both directions
The deflate one matters because every other extraction test stores its entries uncompressed; without a genuinely deflated archive the suite would stay green while every real installation failed.
 
## Notes for review
 
- **Needs the `skip-changelog` label.** The entry is in `tools/compact/CHANGELOG.md`, which is where every CLI entry lives; root `CHANGELOG.md` has never carried one. `changelog-check.yml` greps for root `CHANGELOG.md` plus a `compiler/compiler-version.ss` bump, so any CLI-only PR must either misfile its entry or bump the compiler for a change that does not touch it. A one-line workflow change accepting `tools/compact/CHANGELOG.md` would close that; it is deliberately not in this PR.
- The large `Cargo.lock` diff is `cargo-nextest` coming out, not a dependency change. Aside from the three `zip` additions, no dependency was added or upgraded.
- Reinstalling a version now **replaces** entries rather than merging the archive over whatever was there, since `rename` will not replace a non-empty directory. This is a change from `unzip -o`'s behaviour and is what makes reinstalling over a read-only `compactc` work — nix store files are mode 555, and replacing by rename needs no write permission on the file.
- The pin lands everyone on 1.88.0. If you would rather raise the MSRV, `channel` and `rust-version` move together.